### PR TITLE
chore: remove TRIAGERS.md

### DIFF
--- a/.github/TRIAGERS.md
+++ b/.github/TRIAGERS.md
@@ -1,2 +1,0 @@
-# This file documents Triage members in the Llama Stack community
- @bbrowning @booxter @franciscojavierarceo @leseb


### PR DESCRIPTION
leftover artifact from when this was a LLS midstream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the section listing triage members from the community documentation.
  * No changes to features, UI, or APIs.
  * No configuration or upgrade steps required for users.
  * This update does not affect application behavior or performance.
  * No impact on compatibility across versions.
  * Users and contributors may notice the absence of the previous triage member list in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->