### PR TITLE
chore: move README to root of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Containerfile is auto-generated from a template. To generate it:
    ```
 
 This will:
-- Check for the llama CLI installation
+- Check for the `llama` CLI installation
 - Generate dependencies using `llama stack build`
 - Create a new `Containerfile` with the required dependencies
 
@@ -33,6 +33,7 @@ NEVER edit the generated `Containerfile` manually.
 Once the Containerfile is generated, you can build the image using either Podman or Docker:
 
 ### Using Podman build image for x86_64
+
 ```bash
 podman build --platform linux/amd64 -f redhat-distribution/Containerfile -t rh .
 ```


### PR DESCRIPTION
made sense to have this nested when this was a LLS midstream but no longer

better to have it visible at the root level
