### PR TITLE
chore: add latest image tag for rhoai-2.24

### DIFF
--- a/.github/workflows/redhat-distro-container-build.yml
+++ b/.github/workflows/redhat-distro-container-build.yml
@@ -16,7 +16,8 @@ env:
   # TODO: change the tag to whatever downstream needs
   # IMAGE_NAME: quay.io/opendatahub/llama-stack:odh
   # For now, use the commit SHA that triggered the workflow.
-  IMAGE_NAME: quay.io/opendatahub/llama-stack:${{ github.sha }}
+  IMAGE_NAME: quay.io/opendatahub/llama-stack
+  BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-push:
@@ -52,4 +53,4 @@ jobs:
           file: redhat-distribution/Containerfile
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.IMAGE_NAME }}:${{ env.BRANCH }}-latest


### PR DESCRIPTION
# What does this PR do?
Adds ${branch}-latest tag to the image build for rhoai-v2.24 branch
