### PR TITLE
feat: add bedrock inference provider to redhat distribution

### DIFF
--- a/redhat-distribution/build.yaml
+++ b/redhat-distribution/build.yaml
@@ -4,6 +4,7 @@ distribution_spec:
   providers:
     inference:
     - remote::vllm
+    - remote::bedrock
     - inline::sentence-transformers
     vector_io:
     - inline::milvus

--- a/redhat-distribution/run.yaml
+++ b/redhat-distribution/run.yaml
@@ -19,6 +19,16 @@ providers:
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
+  - provider_id: bedrock-inference
+    provider_type: remote::bedrock
+    config:
+      aws_access_key_id: ${env.AWS_ACCESS_KEY_ID:=}
+      aws_secret_access_key: ${env.AWS_SECRET_ACCESS_KEY:=}
+      aws_session_token: ${env.AWS_SESSION_TOKEN:=}
+      region: ${env.AWS_REGION:=us-east-1}
+      connect_timeout: ${env.AWS_CONNECT_TIMEOUT:=60}
+      read_timeout: ${env.AWS_READ_TIMEOUT:=60}
+      session_ttl: ${env.AWS_SESSION_TTL:=3600}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}


### PR DESCRIPTION
Configure AWS Bedrock as an inference provider with environment-based credentials and connection settings including timeouts and session TTL.

  ## What does this PR do?

Adds AWS Bedrock inference provider to the RedHat distribution. Users can now use Bedrock models alongside the existing vLLM option.

## Test Plan

- The build script ran without errors and generated the Containerfile successfully.
- The YAML config loads properly and  recognizes all 3 inference providers (vllm, bedrock, sentence-transformers) even  without AWS credentials set
