### PR TITLE
feat: Add Bedrock provider support to inference configuration

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -8,6 +8,7 @@ RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 RUN pip install \
     aiosqlite \
     autoevals \
+    boto3 \
     chardet \
     datasets>=4.0.0 \
     fastapi \

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -4,6 +4,7 @@ distribution_spec:
   providers:
     inference:
     - provider_type: remote::vllm
+    - provider_type: remote::bedrock
     - provider_type: inline::sentence-transformers
     vector_io:
     - provider_type: inline::milvus

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -19,6 +19,19 @@ providers:
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
+  - provider_id: bedrock-inference
+    provider_type: remote::bedrock
+    config:
+      aws_access_key_id: ${env.AWS_ACCESS_KEY_ID:=}
+      aws_secret_access_key: ${env.AWS_SECRET_ACCESS_KEY:=}
+      aws_session_token: ${env.AWS_SESSION_TOKEN:=}
+      region_name: ${env.AWS_DEFAULT_REGION:=}
+      profile_name: ${env.AWS_PROFILE:=}
+      total_max_attempts: ${env.AWS_MAX_ATTEMPTS:=}
+      retry_mode: ${env.AWS_RETRY_MODE:=}
+      connect_timeout: ${env.AWS_CONNECT_TIMEOUT:=60}
+      read_timeout: ${env.AWS_READ_TIMEOUT:=60}
+      session_ttl: ${env.AWS_SESSION_TTL:=3600}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}


### PR DESCRIPTION
# What does this PR do?
Adds AWS Bedrock provider support to the llama-stack distribution by configuring the remote::bedrock provider in both build.yaml and run.yaml files. This enables users to leverage AWS Bedrock models for inference through the llama-stack framework.

The changes include:
- Added `remote::bedrock` provider type to build.yaml inference providers
- Added complete bedrock-inference provider configuration in run.yaml with AWS credentials and connection settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Amazon Bedrock as a remote inference provider.
  * Configure Bedrock via environment-backed settings for AWS credentials, region, retries, and timeouts.

* **Chores**
  * Updated container dependencies to include the AWS SDK for Python (boto3) to enable Bedrock integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->