### PR TITLE
chore: bump min required approvals for merge to 2

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
   description: >
     Automatic merge of PRs to main
   conditions:
-    - "#approved-reviews-by>=1"
+    - "#approved-reviews-by>=2"
     - "#review-requested=0"
     - "#changes-requested-reviews-by=0"
     - base=main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated repository auto-merge rules to require two approving reviews (previously one).
  * Disabled automatic conflict pings and “needs-rebase” labeling; contributors should manage conflict resolution proactively.
  * Existing merge checks (e.g., no pending change requests, no review requests, title and pre-commit validations) remain enforced.
  * Base branch restrictions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->