### PR TITLE
feat: add watsonx inference provider and bump lmeval

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -15,6 +15,7 @@ RUN pip install \
     fastapi \
     fire \
     httpx \
+    ibm_watsonx_ai \
     matplotlib \
     mcp>=1.8.1 \
     nltk \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -41,7 +41,7 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.2.4
 RUN pip install \
-    llama_stack_provider_trustyai_fms==0.2.1
+    llama_stack_provider_trustyai_fms==0.2.2
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch torchao>=0.12.0 torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.21

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -6,6 +6,7 @@ distribution_spec:
     - provider_type: remote::vllm
     - provider_type: remote::bedrock
     - provider_type: inline::sentence-transformers
+    - provider_type: remote::watsonx
     vector_io:
     - provider_type: inline::milvus
     - provider_type: remote::milvus

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -12,7 +12,7 @@ distribution_spec:
     - provider_type: remote::milvus
     safety:
     - provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.1
+      module: llama_stack_provider_trustyai_fms==0.2.2
     agents:
     - provider_type: inline::meta-reference
     eval:

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -36,6 +36,12 @@ providers:
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}
+  - provider_id: watsonx
+    provider_type: remote::watsonx
+    config:
+      url: ${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}
+      api_key: ${env.WATSONX_API_KEY:=}
+      project_id: ${env.WATSONX_PROJECT_ID:=}
   vector_io:
   - provider_id: milvus
     provider_type: inline::milvus


### PR DESCRIPTION
8b826423 feat: add watsonx inference provider
ffce08d1 chore: bump lmeval

commit 8b82642302b049708c97e029113a85d28899ea70
Author: Sébastien Han <seb@redhat.com>
Date:   Fri Sep 12 17:10:05 2025 +0200

    feat: add watsonx inference provider
    
    New provider, env variable WATSONX_API_KEY and WATSONX_PROJECT_ID are
    expected to be populated to enable the provider.
    
    Relates to: RHAIENG-1026
    Signed-off-by: Sébastien Han <seb@redhat.com>

commit ffce08d1f1ba9195054d8b8dbfc4475ec420021d
Author: Sébastien Han <seb@redhat.com>
Date:   Fri Sep 12 17:22:21 2025 +0200

    chore: bump lmeval
    
    Fix auth token propagation in the safety provider.
    
    Relates to: RHOAIENG-34050
    Signed-off-by: Sébastien Han <seb@redhat.com>


@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IBM watsonx as a remote inference provider, enabling integration with Watsonx services.
  * Provider configuration supports environment variables for base URL, API key, and project ID.
  * Included in default build and runtime configurations for easy enablement.

* **Chores**
  * Container image now installs the IBM watsonx AI Python client during build, ensuring compatibility with the new provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->