### PR TITLE
fix: Remove port mapping from vllm startup

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -9,7 +9,6 @@ runs:
         # Start vllm container
         docker run -d \
           --name vllm \
-          -p 8000:8000 \
           --privileged=true \
           --net=host \
           quay.io/higginsd/vllm-cpu:65393ee064 \


### PR DESCRIPTION
The container is being started with host networking we don't need to also map a port.

Fixes:
WARNING: Published ports are discarded when using host network mode