### PR TITLE
test: Add granite-embedding-125m model to integration tests

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -53,6 +53,7 @@ function run_integration_tests() {
     uv run pytest -s -v tests/integration/inference/ \
         --stack-config=server:"$STACK_CONFIG_PATH" \
         --text-model=vllm-inference/"$INFERENCE_MODEL" \
+        --embedding-model=granite-embedding-125m \
         -k "not ($SKIP_TESTS)"
 }
 


### PR DESCRIPTION
Enabling granite-embedding-125m will allow the embedding tests to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated integration test script to include an additional embedding-model parameter alongside the existing text-model parameter, ensuring integration tests exercise embedding behavior as well as text handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->