### PR TITLE
feat: add vertexai inference provider

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -14,6 +14,7 @@ RUN pip install \
     'datasets>=4.0.0' \
     fastapi \
     fire \
+    google-cloud-aiplatform \
     httpx \
     ibm_watsonx_ai \
     litellm \

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -16,6 +16,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | inline::sentence-transformers |
 | inference | remote::azure |
 | inference | remote::bedrock |
+| inference | remote::vertexai |
 | inference | remote::vllm |
 | inference | remote::watsonx |
 | safety | remote::trustyai_fms |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -8,6 +8,7 @@ distribution_spec:
     - provider_type: inline::sentence-transformers
     - provider_type: remote::watsonx
     - provider_type: remote::azure
+    - provider_type: remote::vertexai
     vector_io:
     - provider_type: inline::milvus
     - provider_type: remote::milvus

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -49,6 +49,11 @@ providers:
       api_base: ${env.AZURE_API_BASE:=}
       api_version: ${env.AZURE_API_VERSION:=}
       api_type: ${env.AZURE_API_TYPE:=}
+  - provider_id: ${env.VERTEX_AI_PROJECT:+vertexai}
+    provider_type: remote::vertexai
+    config:
+      project: ${env.VERTEX_AI_PROJECT:=}
+      location: ${env.VERTEX_AI_LOCATION:=us-central1}
   vector_io:
   - provider_id: milvus
     provider_type: inline::milvus


### PR DESCRIPTION
# What does this PR do?
Adds VertexAI provider to the midstream distro image

## Test Plan
No testing at this time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud Vertex AI as a remote inference provider; configurable via environment variables for project and location (default: us-central1).

* **Chores**
  * Added the Google Cloud AI client library to the runtime image dependencies; may modestly increase build time and image size.

* **Documentation**
  * Updated provider listings and README to include the new Vertex AI option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->