### PR TITLE
chore: add 'hold' label usage to Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
     - base=main
     - label!=do-not-merge
     - label!=needs-rebase
+    - label!=hold
     - check-success=pre-commit
     - check-success=title-check
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated auto-merge rules to respect a “hold” label, preventing unintended merges when that label is applied.
  - Removed automated conflict notifications and the automatic addition/removal of a “needs-rebase” label to reduce noise.
  - Existing auto-merge requirements (approved reviews, correct base branch, existing label exclusions, and required checks) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->