### PR TITLE
chore: add Kelly as CODEOWNER for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-* @cdoern @derekhiggins @Elbehery @leseb @nathan-weinberg @rhdedgar @rhuss @skamenan7 @VaishnaviHire
+# These owners will own only documentation
+*.md @kelbrown20
 
 # These owners will own only CI and testing related infrastructure
 .github/ @Artemon-line @kami619
 tests/ @Artemon-line @kami619
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+* @cdoern @derekhiggins @Elbehery @leseb @nathan-weinberg @rhdedgar @rhuss @skamenan7 @VaishnaviHire


### PR DESCRIPTION
should also fix a small bug where only the QE guys are getting added for some things