### PR TITLE
feat: fully switch to external provider module method

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -45,8 +45,7 @@ RUN pip install \
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch torchao>=0.12.0 torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.21
-RUN mkdir -p ${HOME}/.llama/providers.d ${HOME}/.cache
+RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
-COPY distribution/providers.d/ ${HOME}/.llama/providers.d/
 
 ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -4,8 +4,7 @@ WORKDIR /opt/app-root
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
 RUN pip install --no-cache llama-stack==0.2.21
-RUN mkdir -p ${{HOME}}/.llama/providers.d ${{HOME}}/.cache
+RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml
-COPY distribution/providers.d/ ${{HOME}}/.llama/providers.d/
 
 ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -42,4 +42,3 @@ additional_pip_packages:
 - psycopg2-binary
 image_type: container
 image_name: llama-stack-rh
-external_providers_dir: distribution/providers.d

--- a/distribution/providers.d/remote/eval/trustyai_lmeval.yaml
+++ b/distribution/providers.d/remote/eval/trustyai_lmeval.yaml
@@ -1,7 +1,0 @@
-adapter:
-  adapter_type: trustyai_lmeval
-  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.2.4"]
-  config_class: llama_stack_provider_lmeval.config.LMEvalEvalProviderConfig
-  module: llama_stack_provider_lmeval
-api_dependencies: ["inference"]
-optional_api_dependencies: []

--- a/distribution/providers.d/remote/safety/trustyai_fms.yaml
+++ b/distribution/providers.d/remote/safety/trustyai_fms.yaml
@@ -1,7 +1,0 @@
-adapter:
-  adapter_type: trustyai_fms
-  pip_packages: ["llama_stack_provider_trustyai_fms==0.2.1"]
-  config_class: llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig
-  module: llama_stack_provider_trustyai_fms
-api_dependencies: ["safety"]
-optional_api_dependencies: ["shields"]

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -68,6 +68,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
+      module: llama_stack_provider_trustyai_fms==0.2.2
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
@@ -86,6 +87,7 @@ providers:
   eval:
   - provider_id: trustyai_lmeval
     provider_type: remote::trustyai_lmeval
+    module: llama_stack_provider_lmeval==0.2.4
     config:
         use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
         base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
@@ -177,4 +179,3 @@ tool_groups:
   provider_id: rag-runtime
 server:
   port: 8321
-external_providers_dir: /opt/app-root/src/.llama/providers.d


### PR DESCRIPTION
# What does this PR do?

delete `providers.d` and depend on `module` for build and run. also delete `external_provider_dir` from both build and run yaml.

this forces `build.py` to only install

uv pip install llama_stack_provider_lmeval==0.2.4
uv pip install llama_stack_provider_trustyai_fms==0.2.2

rather than also grabbing dependencies like `kubernetes`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated provider configuration into the main distribution; removed use of an external providers directory and no longer populating a separate providers folder in builds.

- Chores
  - Bundled safety provider pinned to 0.2.2 and evaluation provider pinned to 0.2.4 in the distribution runtime.

- Removals
  - Removed standalone adapter registrations for the Trustyai LMEval and Trustyai FMS providers; provided via bundled modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->