### PR TITLE
feat: bump llama-stack to 0.2.22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         always_run: true
         files: ^distribution/.*$
         additional_dependencies:
-          - llama-stack==0.2.21
+          - llama-stack==0.2.22
 
       - id: doc-gen
         name: Distribution Documentation

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -20,7 +20,6 @@ RUN pip install \
     mcp>=1.8.1 \
     nltk \
     numpy \
-    openai \
     opentelemetry-exporter-otlp-proto-http \
     opentelemetry-sdk \
     pandas \
@@ -44,7 +43,7 @@ RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.2
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch torchao>=0.12.0 torchvision
 RUN pip install --no-deps sentence-transformers
-RUN pip install --no-cache llama-stack==0.2.21
+RUN pip install --no-cache llama-stack==0.2.22
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
 

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -3,7 +3,7 @@ WORKDIR /opt/app-root
 
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
-RUN pip install --no-cache llama-stack==0.2.21
+RUN pip install --no-cache llama-stack==0.2.22
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -13,7 +13,7 @@ import sys
 from pathlib import Path
 
 BASE_REQUIREMENTS = [
-    "llama-stack==0.2.21",
+    "llama-stack==0.2.22",
 ]
 
 


### PR DESCRIPTION
https://github.com/llamastack/llama-stack/releases/tag/v0.2.22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated the llama-stack dependency to 0.2.22 across build scripts, distribution assets, and pre-commit hooks.
  - Adjusted build/version checks to expect llama-stack 0.2.22; builds will fail if versions mismatch.
  - Removed the OpenAI package from the distribution container image to streamline runtime dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->