### PR TITLE
feat: make inference provider optional

### DIFF
--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -20,7 +20,7 @@ providers:
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
-  - provider_id: bedrock-inference
+  - provider_id: ${env.AWS_ACCESS_KEY_ID:+bedrock}
     provider_type: remote::bedrock
     config:
       aws_access_key_id: ${env.AWS_ACCESS_KEY_ID:=}
@@ -36,7 +36,7 @@ providers:
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}
-  - provider_id: watsonx
+  - provider_id: ${env.WATSONX_API_KEY:+watsonx}
     provider_type: remote::watsonx
     config:
       url: ${env.WATSONX_BASE_URL:=https://us-south.ml.cloud.ibm.com}


### PR DESCRIPTION
Inference provider implementations behave inconsistently—some can load normally without an API key (even though it’s required for proper functionality), while others simply fail. To ensure consistency, we should handle inference providers the same way we do vector I/O providers: treat most of them as optional, with vLLM being the exception.

Relates to: RHAIENG-1178

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic activation of Bedrock integration when AWS credentials are present (no manual provider selection needed).
  * Automatic activation of watsonx integration when a watsonx API key is present.
  * Safer defaults: providers remain inactive unless relevant environment variables are set, avoiding misconfiguration.
* **Chores**
  * Streamlined provider configuration to respect environment-based availability without altering existing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->