### PR TITLE
fix: pip version constraint escaping in container build

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -11,13 +11,13 @@ RUN pip install \
     autoevals \
     boto3 \
     chardet \
-    datasets>=4.0.0 \
+    'datasets>=4.0.0' \
     fastapi \
     fire \
     httpx \
     ibm_watsonx_ai \
     matplotlib \
-    mcp>=1.8.1 \
+    'mcp>=1.8.1' \
     nltk \
     numpy \
     openai \
@@ -26,7 +26,7 @@ RUN pip install \
     pandas \
     pillow \
     psycopg2-binary \
-    pymilvus>=2.4.10 \
+    'pymilvus>=2.4.10' \
     pymongo \
     pypdf \
     redis \
@@ -42,7 +42,7 @@ RUN pip install \
     llama_stack_provider_lmeval==0.2.4
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.2
-RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch torchao>=0.12.0 torchvision
+RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.21
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -80,6 +80,14 @@ def get_dependencies():
                         set(parts[3].split())
                     )  # Sort the package names and remove duplicates
 
+                    # Add quotes to packages with > or < to prevent bash redirection
+                    packages = [
+                        f"'{package}'"
+                        if (">" in package or "<" in package)
+                        else package
+                        for package in packages
+                    ]
+
                     # Determine command type and format accordingly
                     if ("--index-url" in line) or ("--extra-index-url" in line):
                         full_cmd = " ".join(cmd_parts + [" ".join(packages)])


### PR DESCRIPTION
- Add quotes around packages with > or < characters to prevent bash redirection
- Prevents files like '=0.12.0' in final container
- ensures the required version constraints are applied
- Affects packages: datasets>=4.0.0, mcp>=1.8.1, pymilvus>=2.4.10, torchao>=0.12.0


--
```
(base) derekh@laptop:~/workarea/llama-stack-distribution$ podman run -it --entrypoint bash quay.io/opendatahub/llama-stack -c 'ls /opt/app-root'
'=0.12.0'  '=1.8.1'  '=2.4.10'	'=4.0.0'   bin	 etc   include	 lib   lib64   pyvenv.cfg   run.yaml   share   src

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented shell redirection issues during container builds by quoting dependency version constraints so pip installs treat them as literal arguments across all build paths.

- **Chores**
  - Updated several Python package version specifications in the container image for improved stability and compatibility.
  - Standardized pip install argument formatting for more consistent, reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->