### PR TITLE
ci: Skip 3 consistently timing out tests

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -41,7 +41,7 @@ function run_integration_tests() {
     cd "$WORK_DIR"
 
     # Test to skip
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_inference_store_tool_calls"
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_inference_store_tool_calls or test_text_chat_completion_structured_output or test_openai_chat_completion_non_streaming or test_inference_store"
 
     # Dynamically determine the path to run.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/run.yaml"


### PR DESCRIPTION
- test_text_chat_completion_structured_output
- test_openai_chat_completion_non_streaming
- test_inference_store

These tests have been consistently timing out and are now skipped in the integration test suite.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded the integration test skip list to include additional cases, ensuring the test suite runs smoothly in CI.
  * No changes to application behavior or user-facing functionality.
  * Build and deployment workflows remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->