### PR TITLE
ci: Skip a consistently timing out test

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -41,7 +41,7 @@ function run_integration_tests() {
     cd "$WORK_DIR"
 
     # Test to skip
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_inference_store_tool_calls"
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_inference_store_tool_calls or test_text_chat_completion_structured_output"
 
     # Dynamically determine the path to run.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/run.yaml"


### PR DESCRIPTION
- test_text_chat_completion_structured_output

This test has been consistently timing out and is now skipped in the integration test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test runner to exclude an additional flaky test, improving stability and reducing false negatives in CI.
  * No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->