### PR TITLE
fix: bring back milvus-lite

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -25,7 +25,7 @@ RUN pip install \
     pandas \
     pillow \
     psycopg2-binary \
-    'pymilvus>=2.4.10' \
+    'pymilvus[milvus-lite]>=2.4.10' \
     pymongo \
     pypdf \
     redis \

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -88,6 +88,14 @@ def get_dependencies():
                         for package in packages
                     ]
 
+                    # Modify pymilvus package to include milvus-lite extra
+                    packages = [
+                        package.replace("pymilvus", "pymilvus[milvus-lite]")
+                        if "pymilvus" in package
+                        else package
+                        for package in packages
+                    ]
+
                     # Determine command type and format accordingly
                     if ("--index-url" in line) or ("--extra-index-url" in line):
                         full_cmd = " ".join(cmd_parts + [" ".join(packages)])


### PR DESCRIPTION
# What does this PR do?
milvus no longer includes milvus-lite by default

see: https://github.com/milvus-io/pymilvus/pull/2976

this commit modifies our build script to include it otherwise the inline::milvus provider fails on boot

## Test Plan
CI should pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled default support for Milvus Lite via pymilvus[milvus-lite], simplifying local/vector DB usage.
- Chores
  - Updated container configuration to install pymilvus with the milvus-lite extra.
  - Adjusted build process to automatically rewrite pymilvus dependencies to include milvus-lite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->