### PR TITLE
ci: modify image tagging behavior

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -142,6 +142,6 @@ jobs:
           file: distribution/Containerfile
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}${{ github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || '' }}  # only update 'latest' tag if push is to the 'main' branch
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}${{ github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || (startsWith(github.ref, 'refs/heads/rhoai-v') && format(',{0}:{1}-latest', env.IMAGE_NAME, github.ref_name)) || '' }}  # update 'latest' on main, '<branch-name>-latest' on rhoai-v* branches
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
# What does this PR do?
push to 'main' updates 'latest' and SHA tag
push to 'rhoai-v*' updates 'rhoai-v*-latest' and SHA tag
push elsewhere updates just SHA tag



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now adds branch-specific "latest" tags for release branches matching rhoai-v*: image:<branch>-latest.
  * Main branch continues to publish a SHA-based "latest" tag: image:<sha>-latest.
  * Other branches produce no additional "latest" tags.
  * Users can pull branch-specific latest tags for those release branches where available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->