### PR TITLE
fix: deduplicate pymilvus dependency

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -91,7 +91,7 @@ def get_dependencies():
                     # Modify pymilvus package to include milvus-lite extra
                     packages = [
                         package.replace("pymilvus", "pymilvus[milvus-lite]")
-                        if "pymilvus" in package
+                        if "pymilvus" in package and "[milvus-lite]" not in package
                         else package
                         for package in packages
                     ]


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

This PR ensures there is only one pymilvus dependnecy in req.txt.

During bumping LLS version in https://github.com/opendatahub-io/llama-stack-distribution/pull/54, the CI failed upon illegal `pymilvus` dependency in `req.txt`. See CI [run](https://github.com/opendatahub-io/llama-stack-distribution/actions/runs/18126623537/job/51583337085).

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes https://issues.redhat.com/browse/RHAIENG-1312.
## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency handling to only add the milvus-lite extra to pymilvus when it’s not already specified, preventing duplicate or malformed package specifications.
* **Chores**
  * Refined build-time package transformation for more reliable distribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->