### PR TITLE
feat: bump trustyai_fms to v0.2.3

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -42,7 +42,7 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.2.4
 RUN pip install \
-    llama_stack_provider_trustyai_fms==0.2.2
+    --extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.22

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -120,7 +120,14 @@ def get_dependencies():
         all_deps.extend(sorted(no_deps))  # No-deps installs
         all_deps.extend(sorted(no_cache))  # No-cache installs
 
-        return "\n".join(all_deps)
+        # TODO: Remove this once we have a stable PyPI index for trustyai_fms
+        # Fix trustyai_fms package to use test PyPI index
+        result = "\n".join(all_deps)
+        result = result.replace(
+            "llama_stack_provider_trustyai_fms==0.2.3",
+            "--extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3",
+        )
+        return result
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
         print(f"Command output: {e.output}")

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -15,7 +15,7 @@ distribution_spec:
     - provider_type: remote::milvus
     safety:
     - provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms==0.2.3
     agents:
     - provider_type: inline::meta-reference
     eval:

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -85,7 +85,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms==0.2.3
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR bumps trustyai_fms to v0.2.3.

https://test.pypi.org/project/llama-stack-provider-trustyai-fms/

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes: https://issues.redhat.com/browse/RHAIENG-1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the TrustyAI FMS safety provider to v0.2.3 in build and runtime configurations.
  * Adjusted dependency source handling to fetch the new provider version from an alternate package index.
  * Improved installation error reporting to provide clearer diagnostics if a dependency install fails.
  * No changes to workflows, settings, compatibility, or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->