### PR TITLE
ci(docs): add new column detailing default provider enablement

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -8,28 +8,28 @@ The image is currently shipping with upstream Llama Stack version [0.2.22](https
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 
-| API | Provider |
-|-----|----------|
-| agents | inline::meta-reference |
-| datasetio | inline::localfs |
-| datasetio | remote::huggingface |
-| eval | remote::trustyai_lmeval |
-| files | inline::localfs |
-| inference | inline::sentence-transformers |
-| inference | remote::azure |
-| inference | remote::bedrock |
-| inference | remote::openai |
-| inference | remote::vertexai |
-| inference | remote::vllm |
-| inference | remote::watsonx |
-| safety | remote::trustyai_fms |
-| scoring | inline::basic |
-| scoring | inline::braintrust |
-| scoring | inline::llm-as-judge |
-| telemetry | inline::meta-reference |
-| tool_runtime | inline::rag-runtime |
-| tool_runtime | remote::brave-search |
-| tool_runtime | remote::model-context-protocol |
-| tool_runtime | remote::tavily-search |
-| vector_io | inline::milvus |
-| vector_io | remote::milvus |
+| API | Provider | Enabled by default? |
+|-----|----------|---------------------|
+| agents | inline::meta-reference | Yes |
+| datasetio | inline::localfs | Yes |
+| datasetio | remote::huggingface | Yes |
+| eval | remote::trustyai_lmeval | Yes |
+| files | inline::localfs | Yes |
+| inference | inline::sentence-transformers | Yes |
+| inference | remote::azure | No |
+| inference | remote::bedrock | No |
+| inference | remote::openai | No |
+| inference | remote::vertexai | No |
+| inference | remote::vllm | No |
+| inference | remote::watsonx | No |
+| safety | remote::trustyai_fms | Yes |
+| scoring | inline::basic | Yes |
+| scoring | inline::braintrust | Yes |
+| scoring | inline::llm-as-judge | Yes |
+| telemetry | inline::meta-reference | Yes |
+| tool_runtime | inline::rag-runtime | Yes |
+| tool_runtime | remote::brave-search | Yes |
+| tool_runtime | remote::model-context-protocol | Yes |
+| tool_runtime | remote::tavily-search | Yes |
+| vector_io | inline::milvus | Yes |
+| vector_io | remote::milvus | No |

--- a/scripts/gen_distro_docs.py
+++ b/scripts/gen_distro_docs.py
@@ -38,7 +38,10 @@ def extract_llama_stack_version():
 
 def gen_distro_table(providers_data):
     # Start with table header
-    table_lines = ["| API | Provider |", "|-----|----------|"]
+    table_lines = [
+        "| API | Provider | Enabled by default? |",
+        "|-----|----------|---------------------|",
+    ]
 
     # Create a list to collect all API-Provider pairs for sorting
     api_provider_pairs = []
@@ -49,14 +52,25 @@ def gen_distro_table(providers_data):
             for provider in provider_list:
                 if isinstance(provider, dict) and "provider_type" in provider:
                     provider_type = provider["provider_type"]
-                    api_provider_pairs.append((api_name, provider_type))
+                    provider_id = provider.get("provider_id", "")
+
+                    # Check if provider_id contains the conditional syntax ${<something>:+<something>}
+                    # This regex matches the pattern ${...} containing :+
+                    is_conditional = bool(
+                        re.search(r"\$\{[^}]*:\+[^}]*\}", str(provider_id))
+                    )
+                    enabled_by_default = "No" if is_conditional else "Yes"
+
+                    api_provider_pairs.append(
+                        (api_name, provider_type, enabled_by_default)
+                    )
 
     # Sort first by API name, then by provider type
     api_provider_pairs.sort(key=lambda x: (x[0], x[1]))
 
     # Add sorted pairs to table
-    for api_name, provider_type in api_provider_pairs:
-        table_lines.append(f"| {api_name} | {provider_type} |")
+    for api_name, provider_type, enabled_by_default in api_provider_pairs:
+        table_lines.append(f"| {api_name} | {provider_type} | {enabled_by_default} |")
 
     return "\n".join(table_lines)
 


### PR DESCRIPTION
# What does this PR do?
some providers are enabled by default in our distro whereas others require an environmental variable to be set when the container boots

this commit makes that distinction clearer by adding it to our auto-generated docs
