### PR TITLE
feat: bump trustyai_lmeval to v0.3.0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -40,7 +40,7 @@ RUN pip install \
     transformers \
     uvicorn
 RUN pip install \
-    llama_stack_provider_lmeval==0.2.4
+    llama_stack_provider_lmeval==0.3.0
 RUN pip install \
     llama_stack_provider_ragas[remote]==0.3.0
 RUN pip install \

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -20,7 +20,7 @@ distribution_spec:
     - provider_type: inline::meta-reference
     eval:
     - provider_type: remote::trustyai_lmeval
-      module: llama_stack_provider_lmeval==0.2.4
+      module: llama_stack_provider_lmeval==0.3.0
     - provider_type: inline::trustyai_ragas
       module: llama_stack_provider_ragas[remote]==0.3.0
     datasetio:

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -104,7 +104,7 @@ providers:
   eval:
   - provider_id: trustyai_lmeval
     provider_type: remote::trustyai_lmeval
-    module: llama_stack_provider_lmeval==0.2.4
+    module: llama_stack_provider_lmeval==0.3.0
     config:
         use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
         base_url: ${env.VLLM_URL:=}


### PR DESCRIPTION
# What does this PR do?
This PR bumps trustyai_lmeval to v0.3.0.

https://pypi.org/project/llama-stack-provider-lmeval/0.3.0/

Closes: https://issues.redhat.com/browse/RHAIENG-1380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded the evaluation provider dependency to v0.3.0 across container, build, and run configurations to keep components current.
  * No feature or behavior changes are introduced; existing workflows should continue to operate as before.
  * Ensures consistent versioning across distribution artifacts.
  * If you pin versions externally, verify compatibility with v0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->