### PR TITLE
feat: bump trustyai_fms to v0.2.3 official index

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -44,7 +44,7 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_ragas[remote]==0.3.0
 RUN pip install \
-    --extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3
+    llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.22

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -120,13 +120,7 @@ def get_dependencies():
         all_deps.extend(sorted(no_deps))  # No-deps installs
         all_deps.extend(sorted(no_cache))  # No-cache installs
 
-        # TODO: Remove this once we have a stable PyPI index for trustyai_fms
-        # Fix trustyai_fms package to use test PyPI index
         result = "\n".join(all_deps)
-        result = result.replace(
-            "llama_stack_provider_trustyai_fms==0.2.3",
-            "--extra-index-url https://test.pypi.org/simple/ llama_stack_provider_trustyai_fms==0.2.3",
-        )
         return result
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")


### PR DESCRIPTION
# What does this PR do?

This PR bumps trustyai_fms to v0.2.3 official index.

https://pypi.org/project/llama-stack-provider-trustyai-fms/0.2.3/

Closes: https://issues.redhat.com/browse/RHAIENG-1381



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized dependency installation to use the default PyPI, removing a temporary test-index configuration for a specific provider package.
  - Streamlined the build process by removing logic that injected an alternate package index, improving consistency and reliability of installs.
  - No runtime or user-facing behavior changes; installs are more predictable in typical environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->