### PR TITLE
feat: bump trustyai_ragas to v0.3.1.

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -42,7 +42,7 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.2.4
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.0
+    llama_stack_provider_ragas[remote]==0.3.1
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -22,7 +22,7 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.2.4
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.0
+      module: llama_stack_provider_ragas[remote]==0.3.1
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR bumps Ragas provider version to 0.3.1, which is required for LLS 0.2.23.

see https://github.com/trustyai-explainability/community/issues/67

Closes https://issues.redhat.com/browse/RHAIENG-1386

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded the evaluation provider dependency (llama_stack_provider_ragas[remote]) from 0.3.0 to 0.3.1 across build and distribution configurations to adopt the latest patch improvements and maintain compatibility.
  - No functional changes to workflows; installation order and behavior remain unchanged.
  - This update is seamless and requires no user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->