### PR TITLE
fix: add the new entrypoint

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -50,4 +50,4 @@ RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.23
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
-ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -8,4 +8,4 @@ RUN pip install --no-cache llama-stack==0.2.23
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml
 
-ENTRYPOINT ["python", "-m", "llama_stack.core.server.server", "/opt/app-root/run.yaml"]
+ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]


### PR DESCRIPTION
The next 0.3.0 version will have a different way to run the server. The server module does not run the server anymore. It is happening via

```
llama stack run <path to config>
```

For more details https://github.com/llamastack/llama-stack/pull/3625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated container entrypoint to launch via the CLI, providing more consistent startup behavior across environments.
  - Preserves existing configuration (same run YAML path); no action required from users.
  - May result in slightly different log format and signal handling during startup/shutdown.
  - No changes to user-facing APIs or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->