### PR TITLE
fix: add missing llama stack binary

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -75,6 +75,7 @@ jobs:
           source .venv/bin/activate
           pip install --no-cache -e .
           # now remove the install line from the Containerfile
+          cd -
           python3 distribution/build.py
           sed -i '/^RUN pip install --no-cache llama-stack==/d' distribution/Containerfile
 


### PR DESCRIPTION
Let's also pull the right llama stack bin.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Red Hat container build process by using a pinned, isolated build environment for reproducible results.
  * Prepared and activated the build environment before running the distribution build to reduce side effects.
  * Removed duplicate package installation from the container build to avoid redundancy.
  * Increased reliability and consistency of produced container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->