### PR TITLE
docs: detail how to use the image in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,14 @@ The build script will:
 
 The Containerfile is auto-generated from a template. To edit it, you can modify the template in `distribution/Containerfile.in` and run pre-commit again.
 
-> **Warning:**
-*NEVER* edit the generated `Containerfile` manually.
+> [!WARNING]
+> *NEVER* edit the generated `Containerfile` manually.
+
+## Run Instructions
+
+> [!TIP]
+> Ensure you include any env vars you might need for providers in the container env - you can read more about that [here](distribution/README.md).
+
+```bash
+podman run -p 8321:8321 quay.io/opendatahub/llama-stack:latest
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the inline bold warning with a standardized warning admonition for improved readability.
  * Added a Run Instructions section, including a helpful tip and an example container run command to streamline getting started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->