### PR TITLE
feat: bump trustyai_ragas to v0.3.2.

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -40,9 +40,9 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.3.0
 RUN pip install \
-    llama_stack_provider_ragas==0.3.1
+    llama_stack_provider_ragas==0.3.2
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.1
+    llama_stack_provider_ragas[remote]==0.3.2
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,9 +13,9 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | agents | inline::meta-reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.3.1) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.3.2) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.3.0) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.3.1) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.3.2) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -22,9 +22,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.3.0
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.3.1
+      module: llama_stack_provider_ragas==0.3.2
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.1
+      module: llama_stack_provider_ragas[remote]==0.3.2
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
This PR bumps Ragas provider version to 0.3.2,  which is required for LLS 0.2.23.

Closes https://issues.redhat.com/browse/RHAIENG-1386

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the evaluation provider to version 0.3.2 for both inline and remote variants in the distribution build and container image to align with the latest patch release.
- Documentation
  - Refreshed documentation to reflect the provider version bump to 0.3.2 for inline and remote usage, ensuring instructions and tables match the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->