### PR TITLE
ci(fix): mergify should check success of build-test-push when triggered

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,21 @@ pull_request_rules:
     - check-success=pre-commit
     - check-success=title-check
 
+    # Check redhat-distro-container job only when relevant paths are changed
+    - or:
+      - and:
+        - check-success=build-test-push
+        - or:
+          - files~=^\.github/actions/setup-vllm/action\.yml$
+          - files~=^\.github/workflows/redhat-distro-container\.yml$
+          - files~=^distribution/
+          - files~=^tests/
+      - and:
+        - -files~=^\.github/actions/setup-vllm/action\.yml$
+        - -files~=^\.github/workflows/redhat-distro-container\.yml$
+        - -files~=^distribution/
+        - -files~=^tests/
+
   actions:
     merge:
       method: merge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined merge automation to run specific build checks only when related files change, reducing unnecessary runs.
  * Removed automated conflict ping and automatic rebase-label adjustments from the merge workflow.
  * No user-facing functionality changes; product behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->