### PR TITLE
feat: bump trustyai_ragas to v0.3.4.

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -3,6 +3,14 @@
 FROM registry.access.redhat.com/ubi9/python-312@sha256:95ec8d3ee9f875da011639213fd254256c29bc58861ac0b11f290a291fa04435
 WORKDIR /opt/app-root
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
+RUN pip install --upgrade \
+    'kfp-kubernetes==2.14.6' \
+    'pyarrow>=21.0.0' \
+    'botocore==1.35.88' \
+    'boto3==1.35.88' \
+    'aiobotocore==2.16.1' \
+    'ibm-cos-sdk-core==2.14.2' \
+    'ibm-cos-sdk==2.14.2'
 RUN pip install \
     'datasets>=4.0.0' \
     'mcp>=1.8.1' \
@@ -41,9 +49,9 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.3.0
 RUN pip install \
-    llama_stack_provider_ragas==0.3.2
+    llama_stack_provider_ragas==0.3.4
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.2
+    llama_stack_provider_ragas[remote]==0.3.4
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,9 +13,9 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | agents | inline::meta-reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.3.2) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.3.4) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.3.0) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.3.2) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.3.4) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -23,9 +23,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.3.0
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.3.2
+      module: llama_stack_provider_ragas==0.3.4
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.2
+      module: llama_stack_provider_ragas[remote]==0.3.4
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs


### PR DESCRIPTION
This PR bumps Ragas provider version to 0.3.4, which is required for LLS 0.2.23.

Closes https://issues.redhat.com/browse/RHAIENG-1483

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Bumped RAGAS provider versions from 0.3.2 to 0.3.4 across the distribution.
  * Added a set of pinned runtime dependencies (including kfp-kubernetes, pyarrow, botocore, boto3, aiobotocore, ibm-cos-sdk-core, ibm-cos-sdk) and ensure they are installed/upgraded before other packages for deterministic builds.

* Documentation
  * Updated distribution docs and build guidance to reflect provider version bumps and the new pinned dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->