### PR TITLE
feat(vector_io): Add FAISS provider support (RHAIENG-1232)

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -12,6 +12,7 @@ RUN pip install \
     autoevals \
     boto3 \
     chardet \
+    faiss-cpu \
     fastapi \
     fire \
     google-cloud-aiplatform \

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -33,5 +33,6 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | tool_runtime | remote::brave-search | No | ✅ | N/A |
 | tool_runtime | remote::model-context-protocol | No | ✅ | N/A |
 | tool_runtime | remote::tavily-search | No | ✅ | N/A |
+| vector_io | inline::faiss | No | ❌ | Set the `ENABLE_FAISS` environment variable |
 | vector_io | inline::milvus | No | ✅ | N/A |
 | vector_io | remote::milvus | No | ❌ | Set the `MILVUS_ENDPOINT` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -13,6 +13,7 @@ distribution_spec:
     vector_io:
     - provider_type: inline::milvus
     - provider_type: remote::milvus
+    - provider_type: inline::faiss
     safety:
     - provider_type: remote::trustyai_fms
       module: llama_stack_provider_trustyai_fms==0.2.3

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -82,6 +82,27 @@ providers:
         type: sqlite
         namespace: null
         db_path: /opt/app-root/src/.llama/distributions/rh/milvus_remote_registry.db
+  - provider_id: ${env.ENABLE_FAISS:+faiss}
+    provider_type: inline::faiss
+    config:
+      kvstore:
+        type: ${env.FAISS_KVSTORE_TYPE:=sqlite}
+        namespace: ${env.FAISS_KVSTORE_NAMESPACE:=}
+        # SQLite backend (type=sqlite)
+        db_path: ${env.FAISS_KVSTORE_DB_PATH:=}
+        # Redis, PostgreSQL, MongoDB backends (type=redis|postgres|mongodb)
+        host: ${env.FAISS_KVSTORE_HOST:=}
+        port: ${env.FAISS_KVSTORE_PORT:=}
+        # PostgreSQL, MongoDB backends (type=postgres|mongodb)
+        db: ${env.FAISS_KVSTORE_DB:=}
+        user: ${env.FAISS_KVSTORE_USER:=}
+        password: ${env.FAISS_KVSTORE_PASSWORD:=}
+        # PostgreSQL backend only (type=postgres)
+        ssl_mode: ${env.FAISS_KVSTORE_SSL_MODE:=}
+        ca_cert_path: ${env.FAISS_KVSTORE_CA_CERT_PATH:=}
+        table_name: ${env.FAISS_KVSTORE_TABLE_NAME:=}
+        # MongoDB backend only (type=mongodb)
+        collection_name: ${env.FAISS_KVSTORE_COLLECTION_NAME:=}
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms


### PR DESCRIPTION
* Add FAISS as vector_io provider in distribution config
* Support environment variables for flexible kvstore configuration
* Enable conditional FAISS provider via ENABLE_FAISS env var
* Support multiple kvstore backends (SQLite, Redis, PostgreSQL, MongoDB)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional FAISS vector I/O provider, disabled by default. Enable via the ENABLE_FAISS environment variable.
  * Provider is configurable via environment variables for storage/kv settings (type, namespace, path/host, port, database, user/password, SSL mode, CA cert, table/collection names).

* **Documentation**
  * Updated distribution table to include the FAISS provider and guidance on enabling it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->