### PR TITLE
feat: allow for custom run.yaml at container runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,18 @@ Various tags are maintained for this image:
 - `rhoai-v*-latest` will always point to the latest image that has been built off of a merge to the corresponding `rhoai-v*` branch
 
 You can see the source code that implements this build strategy [here](.github/workflows/redhat-distro-container.yml)
+
+### Running with a custom run YAML
+
+The distribution image allows you to run a custom run YAML file within it. To do so, run the image in the following way. The "path" mentioned should be the path to your custom run YAML file.
+
+```bash
+podman run \
+  -p 8321:8321 \
+  -v <path_on_host>:<path_in_container> \
+  -e RUN_CONFIG_PATH=<path_in_container> \
+  quay.io/opendatahub/llama-stack:<tag>
+```
+
+> [!IMPORTANT]
+> The distribution image ships with various dependencies already pre-installed. There is *no* guarantee that your custom run YAML will necessarily work with the included dependencies.

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -61,8 +61,9 @@ RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.3.0rc3+rhai0
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
+COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 #TODO: remove this once we have a stable version of llama-stack
 # LLS server version is not aligned with the client version, so we disable the version check
 # Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
 ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
-ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]
+ENTRYPOINT [ "/opt/app-root/entrypoint.sh" ]

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -4,11 +4,14 @@ WORKDIR /opt/app-root
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
 {llama_stack_install_source}
+
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml
+COPY --chmod=755 distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh
+
 #TODO: remove this once we have a stable version of llama-stack
 # LLS server version is not aligned with the client version, so we disable the version check
 # Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
 ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
 
-ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]
+ENTRYPOINT [ "/opt/app-root/entrypoint.sh" ]

--- a/distribution/entrypoint.sh
+++ b/distribution/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ -n "$RUN_CONFIG_PATH" ] && [ -f "$RUN_CONFIG_PATH" ]; then
+  exec llama stack run "$RUN_CONFIG_PATH" "$@"
+fi
+
+if [ -n "$DISTRO_NAME" ]; then
+  exec llama stack run "$DISTRO_NAME" "$@"
+fi
+
+exec llama stack run /opt/app-root/run.yaml "$@"


### PR DESCRIPTION
# What does this PR do?
this commit changes the server start command to be dynamically generated based on Llama Stack version

it allows users to pass a custom run.yaml if they so choose will keeping the official run.yaml we ship with the distro image as a default

Closes #83 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container startup now supports flexible run configuration, allowing custom run files or configuration identifiers to be specified at launch.

* **Documentation**
  * Added guidance and examples for running the distribution image with custom configuration files (including notes about dependency compatibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->