### PR TITLE
chore: update llama_stack_provider_ragas module versions to 0.3.6

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -49,9 +49,9 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.3.0
 RUN pip install \
-    llama_stack_provider_ragas==0.3.5
+    llama_stack_provider_ragas==0.3.6
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.5
+    llama_stack_provider_ragas[remote]==0.3.6
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,9 +13,9 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | agents | inline::meta-reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.3.5) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.3.0) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.3.5) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -23,9 +23,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.3.0
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.3.5
+      module: llama_stack_provider_ragas==0.3.6
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.5
+      module: llama_stack_provider_ragas[remote]==0.3.6
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs


### PR DESCRIPTION
- Bumped llama_stack_provider_ragas module version from 0.3.5 to 0.3.6 in build.yaml and Containerfile.
- Updated version references in README.md to reflect the new version for both inline and remote configurations.

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Ragas provider component to version 0.3.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->