### PR TITLE
fix: remove sqlite from telemetry sinks

### DIFF
--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -178,8 +178,7 @@ providers:
     provider_type: inline::meta-reference
     config:
       service_name: "${env.OTEL_SERVICE_NAME:=\u200B}"
-      sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
-      sqlite_db_path: /opt/app-root/src/.llama/distributions/rh/trace_store.db
+      sinks: ${env.TELEMETRY_SINKS:=console}
       otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}
   tool_runtime:
   - provider_id: brave-search


### PR DESCRIPTION
Due to changes in upstream LLS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Default telemetry now uses console-only logging, reducing persisted telemetry storage and limiting automatic data retention.
  * The default persisted database path for telemetry traces has been removed, so no local trace file is created by default.
  * Custom telemetry sinks remain supported and can be restored or changed via the TELEMETRY_SINKS environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->