### PR TITLE
feat: bump trustyai_lmeval to v0.3.1.

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -47,7 +47,7 @@ RUN pip install \
     transformers \
     uvicorn
 RUN pip install \
-    llama_stack_provider_lmeval==0.3.0
+    llama_stack_provider_lmeval==0.3.1
 RUN pip install \
     llama_stack_provider_ragas==0.3.6
 RUN pip install \

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -14,7 +14,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
 | eval | inline::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
-| eval | remote::trustyai_lmeval | Yes (version 0.3.0) | ✅ | N/A |
+| eval | remote::trustyai_lmeval | Yes (version 0.3.1) | ✅ | N/A |
 | eval | remote::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -21,7 +21,7 @@ distribution_spec:
     - provider_type: inline::meta-reference
     eval:
     - provider_type: remote::trustyai_lmeval
-      module: llama_stack_provider_lmeval==0.3.0
+      module: llama_stack_provider_lmeval==0.3.1
     - provider_type: inline::trustyai_ragas
       module: llama_stack_provider_ragas==0.3.6
     - provider_type: remote::trustyai_ragas


### PR DESCRIPTION
This PR bumps lmeval provider version to 0.3.1.

Closes https://issues.redhat.com/browse/RHAIENG-1528

Signed-off-by: Mustafa Elbehery <mecd lbeher@redhat.com



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation provider dependencies to the latest stable versions for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->