### PR TITLE
chore: remove default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,3 @@
 # These owners will own only CI and testing related infrastructure
 .github/ @Artemon-line @kami619
 tests/ @Artemon-line @kami619
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-* @cdoern @derekhiggins @Elbehery @leseb @nathan-weinberg @rhdedgar @rhuss @skamenan7 @VaishnaviHire


### PR DESCRIPTION
based on some discussions amongst ourselves

I've left the file including our friends from QE
and Docs to make sure they are in the loop for
relevant changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership defaults: removed the previous repository-wide default owner assignment and retained targeted ownership for documentation and CI/testing areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->