### PR TITLE
chore: update llama_stack_provider_ragas module versions to 0.4.1

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -49,9 +49,9 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.3.1
 RUN pip install \
-    llama_stack_provider_ragas==0.3.6
+    llama_stack_provider_ragas==0.4.1
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.3.6
+    llama_stack_provider_ragas[remote]==0.4.1
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,9 +13,9 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | agents | inline::meta-reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.4.1) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.3.1) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.3.6) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.4.1) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -23,9 +23,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.3.1
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.3.6
+      module: llama_stack_provider_ragas==0.4.1
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.3.6
+      module: llama_stack_provider_ragas[remote]==0.4.1
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -146,7 +146,7 @@ providers:
         namespace: ${env.KUBEFLOW_NAMESPACE:=}
         llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=}
         base_image: ${env.KUBEFLOW_BASE_IMAGE:=}
-        pipelines_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
+        pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface


### PR DESCRIPTION
# What does this PR do?
- Bumped llama_stack_provider_ragas module version from 0.3.6 to 0.4.1 in build.yaml and Containerfile.
- Updated version references in README.md to reflect the new version for both inline and remote configurations.
- Fixed typo in config.

## Test Plan
Re-ran all integration tests & demo notebook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ragas evaluation provider from version 0.3.6 to 0.4.1 across distribution configurations.
  * Updated pipeline token configuration parameter naming in provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->