### PR TITLE
chore: Update ragas provider to 0.4.2

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -49,9 +49,9 @@ RUN pip install \
 RUN pip install \
     llama_stack_provider_lmeval==0.3.1
 RUN pip install \
-    llama_stack_provider_ragas==0.4.1
+    llama_stack_provider_ragas==0.4.2
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.4.1
+    llama_stack_provider_ragas[remote]==0.4.2
 RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -13,9 +13,9 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | agents | inline::meta-reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.4.1) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.4.2) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.3.1) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.4.1) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.4.2) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -23,9 +23,9 @@ distribution_spec:
     - provider_type: remote::trustyai_lmeval
       module: llama_stack_provider_lmeval==0.3.1
     - provider_type: inline::trustyai_ragas
-      module: llama_stack_provider_ragas==0.4.1
+      module: llama_stack_provider_ragas==0.4.2
     - provider_type: remote::trustyai_ragas
-      module: llama_stack_provider_ragas[remote]==0.4.1
+      module: llama_stack_provider_ragas[remote]==0.4.2
     datasetio:
     - provider_type: remote::huggingface
     - provider_type: inline::localfs


### PR DESCRIPTION

# What does this PR do?

- Bumped llama_stack_provider_ragas module version from 0.4.1 to 0.4.2 in build.yaml and Containerfile.
- Updated version references in README.md to reflect the new version for both inline and remote configurations.

## Test Plan
- Provider tests were re-run as well as demo notebook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated llama_stack_provider_ragas to version 0.4.2 across distribution configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->