### PR TITLE
feat: bump llama-stack to 0.3.0rc3+rhai0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         always_run: true
         files: ^distribution/.*$
         additional_dependencies:
-          - llama-stack==0.2.23
+          - git+https://github.com/opendatahub-io/llama-stack.git@v0.3.0rc3+rhai0
 
       - id: doc-gen
         name: Distribution Documentation

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -20,12 +20,12 @@ RUN pip install \
     autoevals \
     boto3 \
     chardet \
+    einops \
     faiss-cpu \
     fastapi \
     fire \
     google-cloud-aiplatform \
     httpx \
-    ibm_watsonx_ai \
     litellm \
     matplotlib \
     nltk \
@@ -39,10 +39,12 @@ RUN pip install \
     pypdf \
     redis \
     requests \
+    safetensors \
     scikit-learn \
     scipy \
     sentencepiece \
     sqlalchemy[asyncio] \
+    tokenizers \
     tqdm \
     transformers \
     uvicorn
@@ -56,7 +58,11 @@ RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.3
 RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision
 RUN pip install --no-deps sentence-transformers
-RUN pip install --no-cache llama-stack==0.2.23
+RUN pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.3.0rc3+rhai0
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
+#TODO: remove this once we have a stable version of llama-stack
+# LLS server version is not aligned with the client version, so we disable the version check
+# Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
+ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
 ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -3,9 +3,12 @@ WORKDIR /opt/app-root
 
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
-RUN pip install --no-cache llama-stack==0.2.23
 {llama_stack_install_source}
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml
+#TODO: remove this once we have a stable version of llama-stack
+# LLS server version is not aligned with the client version, so we disable the version check
+# Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
+ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
 
 ENTRYPOINT ["llama", "stack", "run", "/opt/app-root/run.yaml"]

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with upstream Llama Stack version [0.2.23](https://github.com/llamastack/llama-stack/releases/tag/v0.2.23)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.3.0rc3+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.3.0rc3+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -13,7 +13,7 @@ import sys
 import os
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "0.2.23"
+CURRENT_LLAMA_STACK_VERSION = "0.3.0rc3+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
@@ -30,11 +30,7 @@ PINNED_DEPENDENCIES = [
     "'ibm-cos-sdk==2.14.2'",
 ]
 
-source_install_command = """RUN tmp_build_dir=$(mktemp -d) && \\
-    git clone --filter=blob:none --no-checkout https://github.com/llamastack/llama-stack.git $tmp_build_dir && \\
-    cd $tmp_build_dir && \\
-    git checkout {llama_stack_version} && \\
-    pip install --no-cache -e ."""
+source_install_command = """RUN pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v{llama_stack_version}"""
 
 
 def get_llama_stack_install(llama_stack_version):
@@ -47,8 +43,8 @@ def get_llama_stack_install(llama_stack_version):
 
 
 def is_install_from_source(llama_stack_version):
-    """Check if version string is a git commit SHA (no dots = SHA, has dots = version)."""
-    return "." not in llama_stack_version
+    """Check if version string is a git commit SHA (no dots = SHA, has dots = version) or a custom version (contains +rhai)."""
+    return "." not in llama_stack_version or "+rhai" in llama_stack_version
 
 
 def check_llama_installed():

--- a/scripts/gen_distro_docs.py
+++ b/scripts/gen_distro_docs.py
@@ -21,15 +21,22 @@ def extract_llama_stack_version():
             content = file.read()
 
         # Look for llama-stack version in pip install commands
-        # Pattern matches: llama-stack==X.Y.Z
-        pattern = r"llama-stack==([0-9]+\.[0-9]+\.[0-9]+)"
+        # Pattern matches: llama-stack==X.Y.Z or llama-stack==X.Y.ZrcN+rhaiM
+        pattern = r"llama-stack==([0-9]+\.[0-9]+\.[0-9]+(?:rc[0-9]+)?(?:\+rhai[0-9]+)?)"
         match = re.search(pattern, content)
 
         if match:
             return match.group(1)
-        else:
-            print("Error: Could not find llama-stack version in Containerfile")
-            exit(1)
+
+        # Look for git URL format: git+https://github.com/*/llama-stack.git@vVERSION or @VERSION
+        git_pattern = r"git\+https://github\.com/[^/]+/llama-stack\.git@v?([0-9]+\.[0-9]+\.[0-9]+(?:rc[0-9]+)?(?:\+rhai[0-9]+)?)"
+        git_match = re.search(git_pattern, content)
+
+        if git_match:
+            return git_match.group(1)
+
+        print("Error: Could not find llama-stack version in Containerfile")
+        exit(1)
 
     except Exception as e:
         print(f"Error reading Containerfile: {e}")
@@ -170,7 +177,7 @@ def gen_distro_docs():
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with upstream Llama Stack version [{version}](https://github.com/llamastack/llama-stack/releases/tag/v{version})
+The image is currently shipping with the Open Data Hub version of Llama Stack version [{version}](https://github.com/opendatahub-io/llama-stack/releases/tag/v{version})
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 


### PR DESCRIPTION
# What does this PR do?

This PR bumps LLS version to upstream v0.3.0rc2 tag.

https://github.com/opendatahub-io/llama-stack/releases/tag/v0.3.0rc2%2Brhai0

Relates to: RHAIENG-1685

Closes https://issues.redhat.com/browse/RHAIENG-1685



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to a git-based Llama Stack pre-release, added an env flag to temporarily disable version checks, added einops/safetensors/tokenizers, and removed ibm_watsonx_ai.

* **Documentation**
  * Updated distribution docs and build tooling to reference the Open Data Hub Llama Stack pre-release and adjusted version-detection behavior.

* **Tests**
  * Enabled stricter shell tracing, added a required-config pre-check, expanded test-skip logic, and constrained integration runs to a matching client version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->