### PR TITLE
fix(ci): update concurrency rules

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -31,7 +31,7 @@ on:
     - cron: '0 6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
manually triggered jobs should no longer cancel in-progress jobs running against the main branch

Closes #93 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow concurrency handling to better separate different event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->