### PR TITLE
feat: Update Bedrock provider to use OpenAI-compatible API

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -20,7 +20,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | files | inline::localfs | No | ✅ | N/A |
 | inference | inline::sentence-transformers | No | ✅ | N/A |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
-| inference | remote::bedrock | No | ❌ | Set the `AWS_ACCESS_KEY_ID` environment variable |
+| inference | remote::bedrock | No | ❌ | Set the `AWS_BEDROCK_API_KEY` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -20,19 +20,11 @@ providers:
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
-  - provider_id: ${env.AWS_ACCESS_KEY_ID:+bedrock}
+  - provider_id: ${env.AWS_BEDROCK_API_KEY:+bedrock}
     provider_type: remote::bedrock
     config:
-      aws_access_key_id: ${env.AWS_ACCESS_KEY_ID:=}
-      aws_secret_access_key: ${env.AWS_SECRET_ACCESS_KEY:=}
-      aws_session_token: ${env.AWS_SESSION_TOKEN:=}
-      region_name: ${env.AWS_DEFAULT_REGION:=}
-      profile_name: ${env.AWS_PROFILE:=}
-      total_max_attempts: ${env.AWS_MAX_ATTEMPTS:=}
-      retry_mode: ${env.AWS_RETRY_MODE:=}
-      connect_timeout: ${env.AWS_CONNECT_TIMEOUT:=60}
-      read_timeout: ${env.AWS_READ_TIMEOUT:=60}
-      session_ttl: ${env.AWS_SESSION_TTL:=3600}
+      api_key: ${env.AWS_BEDROCK_API_KEY:=}
+      region_name: ${env.AWS_DEFAULT_REGION:=us-east-2}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}


### PR DESCRIPTION
 This PR updates the Bedrock inference provider configuration to use the simplified OpenAI-compatible API interface introduced in upstream
  llama-stack PR #3748.

  ## Changes

  - Simplified Bedrock provider config in `distribution/run.yaml` from boto3-style (10 parameters) to OpenAI-compatible (2 parameters)
  - Changed provider activation from `AWS_ACCESS_KEY_ID` to `AWS_BEDROCK_API_KEY`
  - Removed boto3-specific parameters: `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `profile_name`, `total_max_attempts`,
   `retry_mode`, `connect_timeout`, `read_timeout`, `session_ttl`
  - Kept only: `api_key` and `region_name` (with default `us-east-2`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Bedrock inference environment variable guidance from AWS_ACCESS_KEY_ID to AWS_BEDROCK_API_KEY.

* **Refactor**
  * Simplified Bedrock provider configuration with API key authentication and default region (us-east-2).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->