### PR TITLE
feat: update Bedrock config to use AWS_BEARER_TOKEN_BEDROCK

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -21,7 +21,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | ❌ | Set the `ENABLE_SENTENCE_TRANSFORMERS` environment variable |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
-| inference | remote::bedrock | No | ❌ | Set the `AWS_ACCESS_KEY_ID` environment variable |
+| inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -27,19 +27,11 @@ providers:
       max_tokens: ${env.VLLM_EMBEDDING_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_EMBEDDING_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_EMBEDDING_TLS_VERIFY:=true}
-  - provider_id: ${env.AWS_ACCESS_KEY_ID:+bedrock}
+  - provider_id: ${env.AWS_BEARER_TOKEN_BEDROCK:+bedrock}
     provider_type: remote::bedrock
     config:
-      aws_access_key_id: ${env.AWS_ACCESS_KEY_ID:=}
-      aws_secret_access_key: ${env.AWS_SECRET_ACCESS_KEY:=}
-      aws_session_token: ${env.AWS_SESSION_TOKEN:=}
-      region_name: ${env.AWS_DEFAULT_REGION:=}
-      profile_name: ${env.AWS_PROFILE:=}
-      total_max_attempts: ${env.AWS_MAX_ATTEMPTS:=}
-      retry_mode: ${env.AWS_RETRY_MODE:=}
-      connect_timeout: ${env.AWS_CONNECT_TIMEOUT:=60}
-      read_timeout: ${env.AWS_READ_TIMEOUT:=60}
-      session_ttl: ${env.AWS_SESSION_TTL:=3600}
+      api_key: ${env.AWS_BEARER_TOKEN_BEDROCK:=}
+      region_name: ${env.AWS_DEFAULT_REGION:=us-east-2}
   - provider_id: ${env.ENABLE_SENTENCE_TRANSFORMERS:+sentence-transformers}
     provider_type: inline::sentence-transformers
     config: {}


### PR DESCRIPTION
## Summary

Update Bedrock configuration to align with upstream llama-stack PR [#4152](https://github.com/llamastack/llama-stack/pull/4152).

## Changes

Replace boto3 credential fields with bearer token configuration.

## Related

- Upstream PR: https://github.com/llamastack/llama-stack/pull/4152
- JIRA: RHAIENG-2046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Bedrock provider setup and environment requirements in distribution docs.

* **Chores**
  * Switched Bedrock authentication to a bearer-token API key sourced from AWS_BEARER_TOKEN_BEDROCK.
  * Removed legacy AWS credential and session fields plus related retry and timeout settings from Bedrock configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->