### PR TITLE
feat: Add S3 remote provider for S3 file storage to LLS midst…

### DIFF
--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -42,6 +42,7 @@ distribution_spec:
     - provider_type: remote::model-context-protocol
     files:
     - provider_type: inline::localfs
+    - provider_type: remote::s3
   container_image: registry.redhat.io/ubi9/python-311:9.6-1749631027
 additional_pip_packages:
 - aiosqlite


### PR DESCRIPTION
This MR enables S3-compatible storage backend support for the files API. The boto3 dependency is automatically resolved by the build system.

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com>

Closes https://issues.redhat.com/browse/RHAIENG-2128



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for remote S3 storage as a new distribution provider option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->