### PR TITLE
feat: bump LLS version to 0.3.3+rhai0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         always_run: true
         files: ^distribution/.*$
         additional_dependencies:
-          - git+https://github.com/opendatahub-io/llama-stack.git@v0.3.0rc3+rhai0
+          - git+https://github.com/opendatahub-io/llama-stack.git@v0.3.3+rhai0
 
       - id: doc-gen
         name: Distribution Documentation

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -12,9 +12,9 @@ RUN pip install --upgrade \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2'
 RUN pip install \
-    'datasets>=4.0.0' \
-    'mcp>=1.8.1' \
-    'pymilvus[milvus-lite]>=2.4.10' \
+    ''datasets>=4.0.0'' \
+    ''mcp>=1.8.1'' \
+    ''pymilvus[milvus-lite]>=2.4.10'' \
     aiosqlite \
     asyncpg \
     autoevals \
@@ -49,21 +49,21 @@ RUN pip install \
     transformers \
     uvicorn
 RUN pip install \
-    llama_stack_provider_lmeval==0.3.1
+    'llama_stack_provider_lmeval==0.3.1'
 RUN pip install \
-    llama_stack_provider_ragas==0.4.2
+    'llama_stack_provider_ragas==0.4.2'
 RUN pip install \
-    llama_stack_provider_ragas[remote]==0.4.2
+    'llama_stack_provider_ragas[remote]==0.4.2'
 RUN pip install \
-    llama_stack_provider_trustyai_fms==0.2.3
-RUN pip install 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision
+    'llama_stack_provider_trustyai_fms==0.2.3'
+RUN pip install ''torchao>=0.12.0'' --extra-index-url https://download.pytorch.org/whl/cpu torch torchvision
 RUN pip install --no-deps sentence-transformers
-RUN pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.3.0rc3+rhai0
+RUN pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.3.3+rhai0
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 #TODO: remove this once we have a stable version of llama-stack
 # LLS server version is not aligned with the client version, so we disable the version check
-# Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
+# Currently, LLS client version is 0.3.0, while the server version is 0.3.3+rhai0
 ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
 ENTRYPOINT [ "/opt/app-root/entrypoint.sh" ]

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -11,7 +11,7 @@ COPY --chmod=755 distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh
 
 #TODO: remove this once we have a stable version of llama-stack
 # LLS server version is not aligned with the client version, so we disable the version check
-# Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
+# Currently, LLS client version is 0.3.0, while the server version is 0.3.3+rhai0
 ENV LLAMA_STACK_DISABLE_VERSION_CHECK=true
 
 ENTRYPOINT [ "/opt/app-root/entrypoint.sh" ]

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.3.0rc3+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.3.0rc3+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.3.3+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.3.3+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -13,7 +13,7 @@ import sys
 import os
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "0.3.0rc3+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "0.3.3+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
@@ -88,8 +88,8 @@ def check_llama_stack_version():
 
 
 def get_dependencies():
-    """Execute the llama stack build command and capture dependencies."""
-    cmd = "llama stack build --config distribution/build.yaml --print-deps-only"
+    """Execute the llama stack list-deps command and capture dependencies."""
+    cmd = "llama stack list-deps --format uv distribution/build.yaml"
     try:
         result = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, check=True

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -33,8 +33,6 @@ distribution_spec:
     - provider_type: inline::basic
     - provider_type: inline::llm-as-judge
     - provider_type: inline::braintrust
-    telemetry:
-    - provider_type: inline::meta-reference
     tool_runtime:
     - provider_type: remote::brave-search
     - provider_type: remote::tavily-search

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -65,7 +65,7 @@ function run_integration_tests() {
     fi
 
     # TODO: remove this once we have a stable version of llama-stack client
-    # Currently, LLS client version is 0.3.0, while the server version is 0.3.0rc3+rhai0
+    # Currently, LLS client version is 0.3.0, while the server version is 0.3.3+rhai0
     uv run --with llama-stack-client==0.3.0 pytest -s -v tests/integration/inference/ \
         --stack-config=server:"$STACK_CONFIG_PATH" \
         --text-model=vllm-inference/"$INFERENCE_MODEL" \


### PR DESCRIPTION
This PR bumps LLS version to 0.3.3+rhai0

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com>

Closes https://issues.redhat.com/browse/RHAIENG-2177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated llama-stack dependency from v0.3.0rc3+rhai0 to v0.3.3+rhai0 across container, build configuration, and pre-commit setup.
  * Added database connectivity packages (aiosqlite, sqlalchemy, asyncpg, psycopg2-binary) to build dependencies.
  * Removed telemetry provider from build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->