### PR TITLE
fix: improve missing package error messages

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -48,10 +48,15 @@ def is_install_from_source(llama_stack_version):
     return "." not in llama_stack_version or "+rhai" in llama_stack_version
 
 
-def check_package_installed(package_name):
-    """Check if llama binary is installed and accessible."""
-    if not shutil.which(package_name):
-        print(f"Error: {package_name} not found. Please install it first.")
+def check_command_installed(command, package_name=None):
+    """Check if a command is installed and accessible."""
+    if not shutil.which(command):
+        if package_name:
+            print(
+                f"Error: {command} not found. Please run uv pip install {package_name}"
+            )
+        else:
+            print(f"Error: {command} not found. Please install it.")
         sys.exit(1)
 
 
@@ -262,11 +267,10 @@ def generate_containerfile(dependencies, llama_stack_install):
 
 
 def main():
-    check_package_installed("uv")
+    check_command_installed("uv")
     install_llama_stack_from_source(LLAMA_STACK_VERSION)
 
-    print("Checking llama installation...")
-    check_package_installed("llama")
+    check_command_installed("llama", "llama-stack-client")
 
     # Do not perform version check if installing from source
     if not is_install_from_source(LLAMA_STACK_VERSION):


### PR DESCRIPTION
## Summary
Improve error messages when required commands are not found by providing specific installation instructions.

## Changes
- Refactor `check_package_installed()` to accept optional package name parameter
- Display `uv pip install` command when `llama` is missing

## Test plan
- Verify error messages display correct installation instructions when commands are missing
- Confirm existing functionality works when commands are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more actionable error messages when required build commands are missing, with optional package hints.
  * Reduced redundant or confusing installation prompts during pre-build checks.

* **Refactor**
  * Unified command/installation validation into a single, consistent flow for simpler, more reliable diagnostics and output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->