### PR TITLE
feat: allow for more customization around embedding model

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -14,7 +14,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | batches | inline::reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.4.1) | ✅ | N/A |
 | eval | remote::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `KUBEFLOW_LLAMA_STACK_URL` environment variable |
 | files | inline::localfs | No | ✅ | N/A |

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -122,18 +122,18 @@ providers:
     provider_type: remote::trustyai_lmeval
     module: llama_stack_provider_lmeval==0.2.4
     config:
-        use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
-        base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
-  - provider_id: ${env.EMBEDDING_MODEL:+trustyai_ragas_inline}
+      use_k8s: ${env.TRUSTYAI_LMEVAL_USE_K8S:=true}
+      base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
+  - provider_id: ${env.TRUSTYAI_EMBEDDING_MODEL:+trustyai_ragas_inline}
     provider_type: inline::trustyai_ragas
     module: llama_stack_provider_ragas.inline
     config:
-      embedding_model: ${env.EMBEDDING_MODEL:=}
+      embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
   - provider_id: ${env.KUBEFLOW_LLAMA_STACK_URL:+trustyai_ragas_remote}
     provider_type: remote::trustyai_ragas
     module: llama_stack_provider_ragas.remote
     config:
-      embedding_model: ${env.EMBEDDING_MODEL:=}
+      embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
       kubeflow_config:
         results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=}
         s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=}
@@ -270,10 +270,10 @@ registered_resources:
     provider_id: vllm-inference
     model_type: llm
   - metadata:
-      embedding_dimension: 768
-    model_id: granite-embedding-125m
+      embedding_dimension: ${env.EMBEDDING_DIMENSION:=768}
+    model_id: ${env.EMBEDDING_MODEL:=granite-embedding-125m-english}
     provider_id: ${env.EMBEDDING_PROVIDER:=vllm-embedding}
-    provider_model_id: ibm-granite/granite-embedding-125m-english
+    provider_model_id: ${env.EMBEDDING_PROVIDER_MODEL_ID:=ibm-granite/granite-embedding-125m-english}
     model_type: embedding
   shields: []
   vector_dbs: []


### PR DESCRIPTION
# What does this PR do?
make embedding dimension, model_id, and provider_model_id configurable fields. prev hardcoded values are now defaults.

update TrustyAI config to use TRUSTYAI_EMBEDDING_MODEL instead of EMBEDDING_MODEL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the environment variable selecting the TrustyAI embedding model for clarity (now TRUSTYAI_EMBEDDING_MODEL).
  * Made embedding configuration environment-driven: embedding dimension, default model ID, and provider model ID now configurable via environment variables.
  * Minor configuration formatting adjustments to align related settings.

* **Documentation**
  * Updated distribution README to reflect the new environment variable name and environment-driven defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->