### PR TITLE
feat: bump trustyai_fms to v0.3.2

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -56,7 +56,7 @@ RUN uv pip install \
 RUN uv pip install \
     llama_stack_provider_ragas[remote]==0.5.1
 RUN uv pip install \
-    llama_stack_provider_trustyai_fms==0.3.1
+    llama_stack_provider_trustyai_fms==0.3.2
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.3.4+rhai0

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -27,7 +27,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_EMBEDDING_URL` environment variable |
 | inference | remote::watsonx | No | ❌ | Set the `WATSONX_API_KEY` environment variable |
-| safety | remote::trustyai_fms | Yes (version 0.3.1) | ✅ | N/A |
+| safety | remote::trustyai_fms | Yes (version 0.3.2) | ✅ | N/A |
 | scoring | inline::basic | No | ✅ | N/A |
 | scoring | inline::braintrust | No | ✅ | N/A |
 | scoring | inline::llm-as-judge | No | ✅ | N/A |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -17,7 +17,7 @@ distribution_spec:
     - provider_type: remote::pgvector
     safety:
     - provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.3.1
+      module: llama_stack_provider_trustyai_fms==0.3.2
     agents:
     - provider_type: inline::meta-reference
     eval:

--- a/distribution/run.yaml
+++ b/distribution/run.yaml
@@ -99,7 +99,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.2.2
+      module: llama_stack_provider_trustyai_fms==0.3.2
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}


### PR DESCRIPTION
This PR bumps trustyai_fms version to v0.3.2

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com>

Closes https://issues.redhat.com/browse/RHAIENG-2408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped TrustyAI FMS provider version to 0.3.2 across deployment and runtime configurations.
* **Documentation**
  * Updated distribution documentation to reflect the TrustyAI FMS provider version change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->