### PR TITLE
fix: update GitHub Actions workflow to handle forked pull requests (fork branch)

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -107,13 +107,13 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Unset VERTEX_AI_PROJECT for fork PRs (secrets not available)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
         run: |
           echo "Unsetting VERTEX_AI_PROJECT for fork PR (secrets not available)"
           echo "VERTEX_AI_PROJECT=" >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud (Vertex)
-        if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+        if: github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ env.VERTEX_AI_PROJECT }}


### PR DESCRIPTION
Modified conditions for unsetting the VERTEX_AI_PROJECT environment variable and authenticating to Google Cloud in the CI workflow.

# What does this PR do?
Fixes the GitHub Actions workflow failure for fork PRs by detecting forks using `github.event.pull_request.head.repo.fork` and gracefully skipping Vertex AI authentication and tests when secrets are unavailable. This allows fork contributors to verify builds while maintaining full test coverage for same-repo PRs and push events.

## Changes Made
- Unset `VERTEX_AI_PROJECT` for fork PRs to prevent authentication attempts
- Updated authentication step to skip fork PRs while allowing push events and same-repo PRs
- Updated test scripts to conditionally include Vertex AI models based on `VERTEX_AI_PROJECT` availability

Check workflow logs for:
- Fork PRs: "Unsetting VERTEX_AI_PROJECT" and "VERTEX_AI_PROJECT is not set, skipping Vertex AI models"
- Same-repo PRs: "Authenticate to Google Cloud" and "VERTEX_AI_PROJECT is set, including Vertex AI models"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve fork pull request handling and streamline authentication logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->