### PR TITLE
fix(security): Pin tornado>=6.5.3 (CVE-2025-67725)

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -11,7 +11,8 @@ RUN uv pip install --upgrade \
     'boto3==1.35.88' \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
-    'ibm-cos-sdk==2.14.2'
+    'ibm-cos-sdk==2.14.2' \
+    'tornado>=6.5.3'
 RUN uv pip install \
     'datasets>=4.0.0' \
     'mcp>=1.23.0' \

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -29,6 +29,7 @@ PINNED_DEPENDENCIES = [
     "'aiobotocore==2.16.1'",
     "'ibm-cos-sdk-core==2.14.2'",
     "'ibm-cos-sdk==2.14.2'",
+    "'tornado>=6.5.3'",  # CVE-2025-67725: Fix Quadratic DoS via Repeated Header Coalescing
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}"""


### PR DESCRIPTION
Addresses Quadratic DoS vulnerability in Tornado's header coalescing.

Refs: https://github.com/tornadoweb/tornado/security/advisories/GHSA-c98p-7wgm-6p64

Signed-off-by: Mustafa Elbehery <melbeher@redhat.com>

closes https://issues.redhat.com/browse/RHOAIENG-41907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to include tornado (version 6.5.3 or higher). This ensures the package is installed consistently across all build environments as part of the deterministic build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->