### PR TITLE
chore: update mcp dependency constraint to >=1.23.0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -19,7 +19,7 @@ RUN pip install \
     ibm_watsonx_ai \
     litellm \
     matplotlib \
-    'mcp>=1.8.1' \
+    'mcp>=1.23.0' \
     nltk \
     numpy \
     opentelemetry-exporter-otlp-proto-http \

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -96,6 +96,14 @@ def get_dependencies():
                         for package in packages
                     ]
 
+                    # pin to mcp>=1.23.0, idealy this would be done in BASE_REQUIREMENTS (above)
+                    # but older version of build.py didn't support this, not adding support now to
+                    # minimise changes in old releases
+                    packages = [
+                        "'mcp>=1.23.0'" if package == "'mcp>=1.8.1'" else package
+                        for package in packages
+                    ]
+
                     # Determine command type and format accordingly
                     if ("--index-url" in line) or ("--extra-index-url" in line):
                         full_cmd = " ".join(cmd_parts + [" ".join(packages)])

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -50,6 +50,12 @@ function run_integration_tests() {
         exit 1
     fi
 
+
+    # we need to prevent uv from syncing uv.lock (as llama-stack-client>=0.2.22 has no upper bound)
+    # This is happening during uv commands because the llama-stack versions in pyproject.toml and uv.lock mismatch
+    sed -i 's/"llama-stack-client>=0\.2\.22"/"llama-stack-client==0.2.23"/g' pyproject.toml
+    uv lock
+
     uv run pytest -s -v tests/integration/inference/ \
         --stack-config=server:"$STACK_CONFIG_PATH" \
         --text-model=vllm-inference/"$INFERENCE_MODEL" \


### PR DESCRIPTION
Updates mcp package version constraint from >=1.8.1 to >=1.23.0 to address security advisory GHSA-9h52-p55h-vw2f.

See: https://github.com/modelcontextprotocol/python-sdk/security/advisories/GHSA-9h52-p55h-vw2f

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->
