### PR TITLE
chore: remove redundant vLLM model registration

### DIFF
--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -271,10 +271,6 @@ storage:
       backend: kv_default
 registered_resources:
   models:
-  - metadata: {}
-    model_id: ${env.INFERENCE_MODEL}
-    provider_id: vllm-inference
-    model_type: llm
   - metadata:
       embedding_dimension: ${env.EMBEDDING_DIMENSION:=768}
     model_id: ${env.EMBEDDING_MODEL:=granite-embedding-125m-english}


### PR DESCRIPTION
## Summary
- Remove explicit model registration for `vllm-inference` provider since vLLM supports dynamic model lookup
- This aligns with the pattern used in `starter` and `ci-tests` distributions
- Embedding model registration is retained as it requires explicit dimension metadata
- 
For JIRA - https://issues.redhat.com/browse/RHAIENG-1913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * A publicly registered inference model was removed from the model registry and was not replaced with an embedding model.
  * Workflows or integrations that referenced that public model may fail; update configurations to point to an available alternative or a private model to restore inference functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->