### PR TITLE
feat: Bump to v0.4.1+rhai0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -14,6 +14,7 @@ RUN uv pip install --prerelease=allow --upgrade \
     'ibm-cos-sdk==2.14.2'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
+    'fonttools>=4.60.2' \
     'mcp>=1.23.0' \
     'pymilvus[milvus-lite]>=2.4.10' \
     aiosqlite \
@@ -59,7 +60,7 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.3.2
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.0+rhai0
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.1+rhai0
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.0+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.0+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.1+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.1+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,7 +15,7 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "v0.4.0+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "v0.4.1+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

This PR bumps LLS version to v0.4.1+rhai0.

This bumps adds `fonttools>=4.60.2` to the image deps.

Signed-off-by: Mustafa Elbehery [melbeher@redhat.com](mailto:melbeher@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated llama-stack to version 0.4.1+rhai0
  * Added fonttools dependency

* **Documentation**
  * Updated version information in distribution documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->