### PR TITLE
chore: remind contributor of potential resync

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -63,3 +63,17 @@ pull_request_rules:
     label:
       remove:
         - needs-rebase
+
+- name: remind about Konflux Dockerfile when Containerfile changes
+  conditions:
+    - files~=^distribution/Containerfile.in$
+    - -closed
+  actions:
+    comment:
+      message: >
+        ⚠️ **Heads up!** This PR modifies `distribution/Containerfile.in`.
+
+        A corresponding change may be needed in the Konflux Dockerfile:
+        https://github.com/red-hat-data-services/llama-stack-distribution/blob/main/Dockerfile.konflux
+
+        Please verify if the changes need to be synchronized.


### PR DESCRIPTION
It's easy to forget changes that need to be resync on https://github.com/red-hat-data-services/llama-stack-distribution/blob/main/Dockerfile.konflux so let's Mergify add a comment in the PR to warn users about this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation rules to post reminder comments on pull requests that modify the Containerfile, ensuring teams stay synchronized with related configuration updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->