### PR TITLE
chore: pin pypdf to 6.1.3 to address GHSA-jfx9-29x2-rv3j

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -45,7 +45,7 @@ RUN pip install \
     llama_stack_provider_trustyai_fms==0.2.2
 RUN pip install --extra-index-url https://download.pytorch.org/whl/cpu torch 'torchao>=0.12.0' torchvision
 RUN pip install --no-deps sentence-transformers
-RUN pip install 'aiohttp==3.13.3' 'fonttools==4.60.2' 'tornado==6.5.3' 'urllib3==2.6.0'
+RUN pip install 'aiohttp==3.13.3' 'fonttools==4.60.2' 'pypdf==6.1.3' 'tornado==6.5.3' 'urllib3==2.6.0'
 RUN pip install --no-cache llama-stack==0.2.22
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/run.yaml ${APP_ROOT}/run.yaml

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -3,7 +3,7 @@ WORKDIR /opt/app-root
 
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {dependencies}
-RUN pip install 'aiohttp==3.13.3' 'fonttools==4.60.2' 'tornado==6.5.3' 'urllib3==2.6.0'
+RUN pip install 'aiohttp==3.13.3' 'fonttools==4.60.2' 'pypdf==6.1.3' 'tornado==6.5.3' 'urllib3==2.6.0'
 RUN pip install --no-cache llama-stack==0.2.22
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/run.yaml ${{APP_ROOT}}/run.yaml


### PR DESCRIPTION
Fixes CVE-2025-62708 where LZWDecode filter could be exploited to cause excessive memory consumption.


