### PR TITLE
fix: Use list-deps --format uv to simplify dependency generation

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -12,57 +12,14 @@ RUN uv pip install --prerelease=allow --upgrade \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2'
-RUN uv pip install --prerelease=allow \
-    'datasets>=4.0.0' \
-    'fonttools>=4.60.2' \
-    'mcp>=1.23.0' \
-    'pymilvus[milvus-lite]>=2.4.10' \
-    aiosqlite \
-    asyncpg \
-    autoevals \
-    boto3 \
-    chardet \
-    einops \
-    faiss-cpu \
-    fastapi \
-    fire \
-    google-cloud-aiplatform \
-    httpx \
-    litellm \
-    matplotlib \
-    nltk \
-    numpy \
-    opentelemetry-exporter-otlp-proto-http \
-    opentelemetry-sdk \
-    pandas \
-    pillow \
-    psycopg2-binary \
-    pymongo \
-    pypdf \
-    qdrant-client \
-    redis \
-    requests \
-    safetensors \
-    scikit-learn \
-    scipy \
-    sentencepiece \
-    sqlalchemy[asyncio] \
-    tokenizers \
-    tqdm \
-    transformers \
-    uvicorn
-RUN uv pip install --prerelease=allow \
-    llama_stack_provider_lmeval==0.4.2
-RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[inline]==0.5.1
-RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[remote]==0.5.1
-RUN uv pip install --prerelease=allow \
-    llama_stack_provider_trustyai_fms==0.3.2
-RUN uv pip install --prerelease=allow \
-    llama_stack_provider_trustyai_garak==0.1.8
-RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
-RUN uv pip install --prerelease=allow --no-deps sentence-transformers
+RUN uv pip install --prerelease=allow 'llama_stack_provider_lmeval==0.4.2'
+RUN uv pip install --prerelease=allow 'llama_stack_provider_ragas[inline]==0.5.1'
+RUN uv pip install --prerelease=allow 'llama_stack_provider_ragas[remote]==0.5.1'
+RUN uv pip install --prerelease=allow 'llama_stack_provider_trustyai_fms==0.3.2'
+RUN uv pip install --prerelease=allow 'llama_stack_provider_trustyai_garak==0.1.8'
+RUN uv pip install --prerelease=allow nltk sqlalchemy[asyncio] google-cloud-aiplatform tqdm numpy 'fonttools>=4.60.2' chardet 'datasets>=4.0.0' 'mcp>=1.23.0' asyncpg safetensors redis aiosqlite matplotlib litellm scipy requests qdrant-client psycopg2-binary sentencepiece transformers pillow pandas boto3 faiss-cpu tokenizers scikit-learn pymongo pypdf autoevals 'pymilvus[milvus-lite]>=2.4.10' 'pymilvus[milvus-lite]>=2.4.10' einops aiosqlite fastapi fire httpx uvicorn opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+RUN uv pip install --prerelease=allow torch torchvision 'torchao>=0.12.0' --extra-index-url https://download.pytorch.org/whl/cpu
+RUN uv pip install --prerelease=allow sentence-transformers --no-deps
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+import subprocess
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from distribution import build  # noqa: E402
+
+
+class GetDependenciesTests(unittest.TestCase):
+    def test_get_dependencies_transforms_and_groups(self) -> None:
+        fake_stdout = "\n".join(
+            [
+                "uv pip install pillow 'fastapi==1.0' aiosqlite 'pymilvus>=2.4.10'",
+                "uv pip install 'pymilvus==2.4.1'",
+                "uv pip install 'llama_stack_provider_ragas.extra==0.5.1'",
+                "uv pip install --extra-index-url https://download.pytorch.org/whl/cu121 'torch==2.2.0'",
+                "uv pip install sentence-transformers --no-deps",
+                "uv pip install --no-deps 'llama-stack-client==1.2.3'",
+                "uv pip install --no-cache 'somepkg>=1.0'",
+                "uv pip install 'llama_stack_provider_lmeval==0.4.2'",
+            ]
+        )
+        completed = subprocess.CompletedProcess(
+            args=["llama", "stack", "list-deps", "--format", "uv"],
+            returncode=0,
+            stdout=fake_stdout,
+            stderr="",
+        )
+
+        with mock.patch(
+            "distribution.build.subprocess.run", return_value=completed
+        ) as run:
+            deps = build.get_dependencies()
+
+        run.assert_called_once()
+
+        # Pinned deps must be first.
+        first_line = deps.splitlines()[0]
+        self.assertTrue(
+            first_line.startswith("RUN uv pip install --prerelease=allow --upgrade"),
+            msg=first_line,
+        )
+
+        # Verify conversions are applied.
+        self.assertIn("pymilvus[milvus-lite]==2.4.1", deps)
+        self.assertIn("llama_stack_provider_ragas[extra]==0.5.1", deps)
+
+        # Quote rules are enforced by list-deps --format uv (per upstream):
+        # quoted: contains comparison operators or equals; unquoted: plain names.
+        self.assertIn("pillow", deps)
+        self.assertIn("sentence-transformers --no-deps", deps)
+        self.assertIn("'pymilvus[milvus-lite]>=2.4.10'", deps)
+        self.assertIn("'llama_stack_provider_lmeval==0.4.2'", deps)
+
+        # Verify special flags are preserved.
+        self.assertIn("--extra-index-url https://download.pytorch.org/whl/cu121", deps)
+        self.assertIn("--no-deps 'llama-stack-client==1.2.3'", deps)
+        self.assertIn("--no-cache 'somepkg>=1.0'", deps)
+
+        # Ensure each install command uses prerelease allow.
+        for line in deps.splitlines():
+            if line.startswith("RUN uv pip install"):
+                self.assertIn("--prerelease=allow", line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

- Changes
  - Switch distribution/build.py:get_dependencies() to consume llama stack list-deps --format uv output directly.
  - Simplify parsing to preserve upstream quoting behavior while still applying local pymilvus and .extra rewrites.
  - Add a tests/test_build.py unit test to validate dependency grouping and quote-preservation.
- Benefits
  - Aligns dependency generation with upstream quoting rules, avoiding shell-escaping issues.
  - Reduces custom parsing logic, making the build script easier to maintain.
  - Adds test coverage to guard against regressions in dependency formatting.
  
@leseb can you help review if this align with your thinking? Thanks!

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated and standardized how dependencies are discovered and installed, ensuring consistent handling of extras, quoted packages and special flags (--extra-index-url, --no-deps, --no-cache) and enforcing prerelease allowance for installs.
* **Tests**
  * Added tests validating dependency transformations, grouping, quoting rules and preservation of install flags and prerelease behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->