### PR TITLE
fix: Bump to 0.4.2.1+rhai0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -63,7 +63,7 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2+rhai0
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.2+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.2+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.2.1+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.2.1+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,8 +15,9 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "v0.4.2+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "v0.4.2.1+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
+LLAMA_STACK_CLIENT_VERSION = "v0.4.2"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
 ]
@@ -37,9 +38,12 @@ RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_
 
 
 def get_llama_stack_install(llama_stack_version):
-    # We use the same version for llama-stack and llama-stack-client and just remove the downstream
-    # tag +rhai[0-9]+
-    llama_stack_client_version = llama_stack_version.split("+")[0]
+    # Use explicit client version if set, otherwise derive from llama_stack_version by removing +rhai suffix
+    llama_stack_client_version = (
+        LLAMA_STACK_CLIENT_VERSION
+        if LLAMA_STACK_CLIENT_VERSION
+        else llama_stack_version.split("+")[0]
+    )
     # If the version is a commit SHA or a short commit SHA, we need to install from source
     if is_install_from_source(llama_stack_version):
         print(f"Installing llama-stack from source: {llama_stack_version}")


### PR DESCRIPTION
Also update to build.py to allow client version override


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Llama Stack to version v0.4.2.1+rhai0 across distribution configuration and build settings
  * Added configurable version derivation for improved flexibility in version management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->