### PR TITLE
chore(deps)!: bump llama_stack_provider_trustyai_fms to 0.4.0 for lls 0.5.0 compatibility

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -59,7 +59,7 @@ RUN uv pip install --prerelease=allow \
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_ragas[remote]==0.5.1
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_trustyai_fms==0.3.2
+    llama_stack_provider_trustyai_fms==0.4.0
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -28,7 +28,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_EMBEDDING_URL` environment variable |
 | inference | remote::watsonx | No | ❌ | Set the `WATSONX_API_KEY` environment variable |
-| safety | remote::trustyai_fms | Yes (version 0.3.2) | ✅ | N/A |
+| safety | remote::trustyai_fms | Yes (version 0.4.0) | ✅ | N/A |
 | scoring | inline::basic | No | ✅ | N/A |
 | scoring | inline::braintrust | No | ✅ | N/A |
 | scoring | inline::llm-as-judge | No | ✅ | N/A |

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -115,7 +115,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.3.2
+      module: llama_stack_provider_trustyai_fms==0.4.0
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}


### PR DESCRIPTION
## Introduction

There are breaking changes introduced in llama stack 0.5.0 in the context of safety providers; e.g. see [here](https://hackmd.io/@7FIgxbJfSliRvRtcYpoXFw/r1c6_27P-g#3-Safety-API-Provider-Interface-Changes-4643)

This PR bumps the safety provider to version [0.4.0](https://github.com/trustyai-explainability/llama-stack-provider-trustyai-fms/releases/tag/0.4.0) in an attempt to deal with these breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the trustyai_fms provider to version 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->