### PR TITLE
chore(deps): bump llama_stack_provider_trustyai_garak to 0.2.0 and add new benchmarks

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -61,7 +61,7 @@ RUN uv pip install --prerelease=allow \
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.4.0
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_trustyai_garak==0.1.8
+    llama_stack_provider_trustyai_garak==0.2.0
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.5.0+rhai0

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -15,7 +15,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
 | eval | inline::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
-| eval | remote::trustyai_garak | Yes (version 0.1.8) | ❌ | Set the `ENABLE_KUBEFLOW_GARAK` environment variable |
+| eval | remote::trustyai_garak | Yes (version 0.2.0) | ❌ | Set the `ENABLE_KUBEFLOW_GARAK` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.4.2) | ✅ | N/A |
 | eval | remote::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
 | files | inline::localfs | No | ✅ | N/A |

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -160,16 +160,15 @@ providers:
         pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
   - provider_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak_remote}
     provider_type: remote::trustyai_garak
-    module: llama_stack_provider_trustyai_garak==0.1.8
+    module: llama_stack_provider_trustyai_garak==0.2.0
     config:
       llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL:=}
       kubeflow_config:
-        results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=}
-        s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=}
         pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=}
         namespace: ${env.KUBEFLOW_NAMESPACE:=}
-        base_image: ${env.KUBEFLOW_BASE_IMAGE:=}
+        garak_base_image: ${env.KUBEFLOW_GARAK_BASE_IMAGE:=}
         pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
+        experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=}
   datasetio:
   - provider_id: huggingface
     provider_type: remote::huggingface
@@ -317,12 +316,24 @@ registered_resources:
       - garak_scoring
     provider_id: trustyai_garak_remote
     provider_benchmark_id: quick
-  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::standard}
+  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::avid}
     dataset_id: garak
     scoring_functions:
       - garak_scoring
     provider_id: trustyai_garak_remote
-    provider_benchmark_id: standard
+    provider_benchmark_id: trustyai_garak::avid
+  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::quality}
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak_remote
+    provider_benchmark_id: trustyai_garak::quality
+  - benchmark_id: ${env.ENABLE_KUBEFLOW_GARAK:+trustyai_garak::cwe}
+    dataset_id: garak
+    scoring_functions:
+      - garak_scoring
+    provider_id: trustyai_garak_remote
+    provider_benchmark_id: trustyai_garak::cwe
   tool_groups:
   - toolgroup_id: builtin::websearch
     provider_id: tavily-search


### PR DESCRIPTION
This PR bumps `trustyai_garak` eval provider version to `0.2.0` to be compatible with Llama Stack v0.5.0 and adds new benchmarks for garak provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Upgraded trustyai_garak provider to v0.2.0
  * Updated benchmark configuration and defaults

* **New Features**
  * Added two new trustyai_garak benchmarks: quality and cwe evaluations
  * Introduced an avid benchmark variant and experiment naming support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->