### PR TITLE
chore(deps): update llama_stack_provider_ragas to version 0.6.0 in configuration and documentation

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -55,9 +55,9 @@ RUN uv pip install --prerelease=allow \
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_lmeval==0.4.2
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[inline]==0.5.1
+    llama_stack_provider_ragas[inline]==0.6.0
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[remote]==0.5.1
+    llama_stack_provider_ragas[remote]==0.6.0
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.4.0
 RUN uv pip install --prerelease=allow \

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -14,10 +14,10 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | batches | inline::reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.6.0) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_garak | Yes (version 0.2.0) | ❌ | Set the `ENABLE_KUBEFLOW_GARAK` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.4.2) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.6.0) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | ❌ | Set the `ENABLE_SENTENCE_TRANSFORMERS` environment variable |

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -142,12 +142,12 @@ providers:
       base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
   - provider_id: ${env.TRUSTYAI_EMBEDDING_MODEL:+trustyai_ragas_inline}
     provider_type: inline::trustyai_ragas
-    module: llama_stack_provider_ragas.inline==0.5.1
+    module: llama_stack_provider_ragas.inline==0.6.0
     config:
       embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
   - provider_id: ${env.ENABLE_KUBEFLOW_RAGAS:+trustyai_ragas_remote}
     provider_type: remote::trustyai_ragas
-    module: llama_stack_provider_ragas.remote==0.5.1
+    module: llama_stack_provider_ragas.remote==0.6.0
     config:
       embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
       kubeflow_config:


### PR DESCRIPTION
# What does this PR do?
Bumps the inline and remote llama_stack_provider_ragas modules to version 0.6.0 in the config.yaml and Containerfile. Updates README.md to reflect the new version for the trustyai_ragas provider.

Gitlab counterpart: https://gitlab.com/redhat/rhel-ai/llama-stack/pipeline/-/merge_requests/335

## Test Plan
- Ragas provider 0.6.0 has been tested with LLS 0.5.0
