### PR TITLE
fix: Pin llama-stack-api the same way as llama-stack-client

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -65,6 +65,7 @@ RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
+RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.2
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -34,7 +34,8 @@ PINNED_DEPENDENCIES = [
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}
-RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}"""
+RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}
+RUN uv pip install --no-cache --no-deps llama-stack-api=={llama_stack_api_version}"""
 
 
 def get_llama_stack_install(llama_stack_version):
@@ -44,12 +45,15 @@ def get_llama_stack_install(llama_stack_version):
         if LLAMA_STACK_CLIENT_VERSION
         else llama_stack_version.split("+")[0]
     )
+    llama_stack_api_version = llama_stack_client_version
+
     # If the version is a commit SHA or a short commit SHA, we need to install from source
     if is_install_from_source(llama_stack_version):
         print(f"Installing llama-stack from source: {llama_stack_version}")
         return source_install_command.format(
             llama_stack_version=llama_stack_version,
             llama_stack_client_version=llama_stack_client_version,
+            llama_stack_api_version=llama_stack_api_version,
         ).rstrip()
 
 


### PR DESCRIPTION
o Include llama-stack-api in source_install_command template 
o Pass api version through get_llama_stack_install() 
o Add pinned install line to Containerfile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build and deployment configuration to include llama-stack-api package installation (v0.4.2) during environment setup.
  * Enhanced installation process to automatically deploy llama-stack-api alongside llama-stack-client when installing from source, with synchronized versioning to ensure compatibility and consistency across both packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->