### PR TITLE
fix: Pin llama-stack-api to v0.4.4

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -66,6 +66,7 @@ RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
+RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.4
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -18,6 +18,7 @@ from pathlib import Path
 CURRENT_LLAMA_STACK_VERSION = "v0.4.2.1+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 LLAMA_STACK_CLIENT_VERSION = "v0.4.2"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
+LLAMA_STACK_API_VERSION = "v0.4.4"  # pre-0.4.4 had broken packaging (llama-stack#4777)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
 ]
@@ -35,7 +36,8 @@ PINNED_DEPENDENCIES = [
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}
-RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}"""
+RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}
+RUN uv pip install --no-cache --no-deps llama-stack-api=={llama_stack_api_version}"""
 
 
 def get_llama_stack_install(llama_stack_version):
@@ -51,6 +53,7 @@ def get_llama_stack_install(llama_stack_version):
         return source_install_command.format(
             llama_stack_version=llama_stack_version,
             llama_stack_client_version=llama_stack_client_version,
+            llama_stack_api_version=LLAMA_STACK_API_VERSION,
         ).rstrip()
 
 


### PR DESCRIPTION
Pre-0.4.4 had broken packaging https://github.com/llamastack/llama-stack/pull/4777 
fix: pin setuptools to 81.0.0