### PR TITLE
chore: Replace vllm container with uv installed vllm-cpu

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -1,28 +1,27 @@
 name: Setup VLLM
-description: Start VLLM
+description: Install and start VLLM (CPU)
 runs:
   using: "composite"
   steps:
     - name: Start VLLM
       shell: bash
       run: |
-        # Start vllm container
-        docker run -d \
-          --name vllm \
-          --privileged=true \
-          --net=host \
-          quay.io/higginsd/vllm-cpu:65393ee064-qwen3 \
+        uv venv
+        uv pip install --index https://download.pytorch.org/whl/cpu torch==2.10.0+cpu torchvision
+        uv pip install vllm-cpu==v0.15.0
+
+        # Need to pin numpy to 2.2.6 for vllm-cpu==v0.15.0, "ImportError: Numba needs NumPy 2.2 or less. Got NumPy 2.3."
+        uv run --with numpy==2.2.6 vllm serve Qwen/Qwen3-0.6B \
           --host 0.0.0.0 \
           --port 8000 \
           --enable-auto-tool-choice \
           --tool-call-parser hermes \
-          --model /root/.cache/Qwen3-0.6B \
           --served-model-name Qwen/Qwen3-0.6B \
-          --max-model-len 8192
+          --max-model-len 8192 \
+          > /tmp/vllm.log 2>&1 &
 
-          # Wait for vllm to be ready
-          echo "Waiting for vllm to be ready..."
-          timeout 900 bash -c 'until curl -fsS http://localhost:8000/health >/dev/null; do
-            echo "Waiting for vllm..."
-            sleep 5
-          done'
+        echo "Waiting for vllm to be ready..."
+        timeout 900 bash -c 'until curl -f http://localhost:8000/health; do
+          echo "Waiting for vllm..."
+          sleep 5
+        done'

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -184,7 +184,7 @@ jobs:
           mkdir -p logs
 
           docker logs llama-stack > logs/llama-stack.log 2>&1 || echo "Failed to get llama-stack logs" > logs/llama-stack.log
-          docker logs vllm > logs/vllm.log 2>&1 || echo "Failed to get vllm logs" > logs/vllm.log
+          cp /tmp/vllm.log logs/vllm.log 2>/dev/null || echo "No vllm logs found" > logs/vllm.log
           docker logs postgres > logs/postgres.log 2>&1 || echo "Failed to get postgres logs" > logs/postgres.log
 
           # Gather system information


### PR DESCRIPTION
o Install CPU PyTorch and vllm-cpu via uv pip instead of pulling a Docker container image
o Run vllm as a background process with logs to /tmp/vllm.log
o Pin numpy to 2.2.6 to work around Numba incompatibility with NumPy 2.3
o Update log collection to copy from log file instead of docker logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized VLLM setup process by migrating from Docker-based to native Python environment configuration.
  * Updated log collection mechanism for improved debugging workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->