### PR TITLE
fix: Remove --prerelease=allow from pip installs

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/python-312@sha256:95ec8d3ee9f875da011639213
 WORKDIR /opt/app-root
 RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
-RUN uv pip install --prerelease=allow opentelemetry-distro
-RUN uv pip install --prerelease=allow --upgrade \
+RUN uv pip install opentelemetry-distro
+RUN uv pip install --upgrade \
     'kfp-kubernetes==2.14.6' \
     'pyarrow>=21.0.0' \
     'botocore==1.35.88' \
@@ -14,7 +14,7 @@ RUN uv pip install --prerelease=allow --upgrade \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2' \
     'setuptools==81.0.0'
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \
     'mcp>=1.23.0' \
@@ -53,21 +53,21 @@ RUN uv pip install --prerelease=allow \
     tqdm \
     transformers \
     uvicorn
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     llama_stack_provider_lmeval==0.5.0
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     llama_stack_provider_ragas[inline]==0.6.0
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     llama_stack_provider_ragas[remote]==0.6.0
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     llama_stack_provider_trustyai_fms==0.4.0
-RUN uv pip install --prerelease=allow \
+RUN uv pip install \
     llama_stack_provider_trustyai_garak==0.2.0
-RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
-RUN uv pip install --prerelease=allow --no-deps sentence-transformers
+RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
+RUN uv pip install --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.5.0+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.5.0
-RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --prerelease=allow --requirement -
+RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -3,12 +3,12 @@ WORKDIR /opt/app-root
 
 RUN pip install uv
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
-RUN uv pip install --prerelease=allow opentelemetry-distro
+RUN uv pip install opentelemetry-distro
 
 {dependencies}
 {llama_stack_install_source}
 
-RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --prerelease=allow --requirement -
+RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
 COPY distribution/config.yaml ${{APP_ROOT}}/config.yaml

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -148,10 +148,7 @@ def get_dependencies():
                 continue
 
             # New format: just packages, possibly with flags
-            # Fixes: https://issues.redhat.com/browse/RHAIENG-2710
-            # TODO: remove this once we have a stable version of kubernetes.
-            # Use --prerelease=allow to permit pre-release dependencies (e.g. kubernetes==35.0.0a1)
-            cmd_parts = ["RUN", "uv", "pip", "install", "--prerelease=allow"]
+            cmd_parts = ["RUN", "uv", "pip", "install"]
             packages_str = line
 
             # Parse packages and flags from the line
@@ -234,7 +231,7 @@ def get_dependencies():
         # Add pinned dependencies FIRST to ensure version compatibility
         if PINNED_DEPENDENCIES:
             pinned_packages = " \\\n    ".join(PINNED_DEPENDENCIES)
-            pinned_cmd = f"RUN uv pip install --prerelease=allow --upgrade \\\n    {pinned_packages}"
+            pinned_cmd = f"RUN uv pip install --upgrade \\\n    {pinned_packages}"
             all_deps.append(pinned_cmd)
 
         all_deps.extend(sorted(standard_deps))  # Regular pip installs


### PR DESCRIPTION
milvus-lite 2.5.2rc1 (released 2026-02-22) ships a binary requiring GLIBCXX_3.4.30 which is not available on UBI9 (GCC 11 provides up to 3.4.29), causing the container to fail at runtime. Dropping --prerelease=allow prevents uv from picking up broken release candidates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build to install stable (non-prerelease) package versions for OpenTelemetry and other dependencies.
  * Reorganized package installation into more granular steps to improve build clarity.
  * Added an entrypoint script and an environment toggle to the container startup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->