### PR TITLE
fix: add missing results_s3_endpoint and results_s3_path_style to kub…

### DIFF
--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -152,6 +152,8 @@ providers:
       embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
       kubeflow_config:
         results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX:=}
+        results_s3_endpoint: ${env.KUBEFLOW_RESULTS_S3_ENDPOINT:=https://s3.us-east-1.amazonaws.com}
+        results_s3_path_style: ${env.KUBEFLOW_RESULTS_S3_PATH_STYLE:=false}
         s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME:=}
         pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=}
         namespace: ${env.KUBEFLOW_NAMESPACE:=}


### PR DESCRIPTION
…eflow_config

The rh distribution config was missing these two fields in the trustyai_ragas kubeflow_config. The env vars (KUBEFLOW_RESULTS_S3_ENDPOINT and KUBEFLOW_RESULTS_S3_PATH_STYLE) are present in the pod but were never read by the provider config, preventing the use of S3-compatible providers like MinIO for results storage.

# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two new configuration options to customize S3 storage access (endpoint URL and path-style addressing). Defaults are provided and both settings can be overridden through environment variables so deployments can target alternate S3-compatible endpoints or enable path-style addressing for compatibility with different storage providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->