### PR TITLE
chore: update Slack notification conditions in CI workflow

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -242,9 +242,9 @@ jobs:
         if: failure()
         run: echo "NOTIFY_FAILURE=1" >> "$GITHUB_ENV"
 
-      # Notify Slack: on success (when image published) or on failure
+      # Notify Slack: on success (when image published) or on failure; only on push/workflow_dispatch/schedule, not on pull_request
       - name: Notify Slack
-        if: always() && (failure() || (success() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && steps.distribution-changed.outputs.changed == 'true'))))
+        if: always() && github.event_name != 'pull_request' && (failure() || (success() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && steps.distribution-changed.outputs.changed == 'true'))))
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.WH_SLACK_TEAM_LLS_CORE }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
Modified the Slack notification step in the GitHub Actions workflow to ensure notifications are sent only on successful image publications or failures, excluding pull request events. This change clarifies the conditions under which notifications are triggered, aligning with recent updates to the publish logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow notification configuration to refine event triggers and provide additional deployment context information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->