### PR TITLE
ci: enable tests for multi-arch arm64 builds

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -43,8 +43,20 @@ env:
   IMAGE_NAME: quay.io/opendatahub/llama-stack # tags for the image will be added dynamically
 
 jobs:
-  build-test-push:
-    runs-on: ubuntu-latest
+  build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      distribution-changed: ${{ steps.distribution-changed.outputs.changed }}
     env:
       VERTEX_AI_PROJECT: ${{ secrets.VERTEX_AI_PROJECT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -58,9 +70,6 @@ jobs:
       VLLM_URL: http://localhost:8000/v1
       VLLM_EMBEDDING_URL: http://localhost:8001/v1
       LLAMA_STACK_COMMIT_SHA: ${{ github.event.inputs.llama_stack_commit_sha || 'main' }}
-    strategy:
-      matrix:
-        platform: [linux/amd64] # Build AMD64 for testing (load: true only works for single platform)
     permissions:
       id-token: write # for Google Cloud authentication
       contents: read
@@ -89,9 +98,7 @@ jobs:
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
           python-version: 3.12
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+          enable-cache: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -113,7 +120,7 @@ jobs:
           python3 distribution/build.py
           sed -i '/^RUN pip install --no-cache llama-stack==/d' distribution/Containerfile
 
-      - name: Build image (AMD64 for testing)
+      - name: Build image for testing (${{ matrix.arch }})
         id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -122,22 +129,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           tags: ${{ env.IMAGE_NAME }}:${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && format('source-{0}-{1}', env.LLAMA_STACK_COMMIT_SHA, github.sha) || github.sha }}
-          load: true  # needed to load for smoke test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build image (ARM64 verification)
-        id: build-arm64
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          file: distribution/Containerfile
-          platforms: linux/arm64
-          push: false
-          tags: ${{ env.IMAGE_NAME }}:${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && format('source-{0}-{1}-arm64', env.LLAMA_STACK_COMMIT_SHA, github.sha) || format('{0}-arm64', github.sha) }}
-          load: false  # Only verify it builds, don't load (can't load ARM64 on AMD64 runner)
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          load: true
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
 
       - name: Unset cloud provider credentials for fork and Dependabot PRs (secrets not available)
         if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork == true || github.secret_source == 'Dependabot')
@@ -150,7 +144,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud (Vertex)
-        if: github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
+        if: matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ env.VERTEX_AI_PROJECT }}
@@ -181,12 +175,10 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         id: smoke-test
         shell: bash
-        env:
-          IMAGE_TAG: ${{ contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name) && format('source-{0}-{1}', env.LLAMA_STACK_COMMIT_SHA, github.sha) || github.sha }}
         run: ./tests/smoke.sh
 
       - name: Integration tests
-        if: github.event_name != 'workflow_dispatch'
+        if: matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch'
         id: integration-tests
         shell: bash
         run: ./tests/run_integration_tests.sh
@@ -228,7 +220,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ci-logs-${{ github.sha }}
+          name: ci-logs-${{ matrix.arch }}-${{ github.sha }}
           path: logs/
           retention-days: 7
 
@@ -238,36 +230,13 @@ jobs:
         run: |
           docker rm -f vllm-inference vllm-embedding llama-stack postgres
 
-      - name: Log in to Quay.io
-        id: login
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && steps.distribution-changed.outputs.changed == 'true')
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Publish multi-arch image to Quay.io
-        id: publish
-        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && steps.distribution-changed.outputs.changed == 'true')
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: .
-          file: distribution/Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ github.event_name == 'workflow_dispatch' && format('{0}:source-{1}-{2}', env.IMAGE_NAME, env.LLAMA_STACK_COMMIT_SHA, github.sha) || format('{0}:{1}{2}', env.IMAGE_NAME, github.sha, github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || (startsWith(github.ref, 'refs/heads/rhoai-v') && format(',{0}:{1}-latest', env.IMAGE_NAME, github.ref_name)) || '') }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       # Set status so the single Notify step knows whether to send success or failure message.
       - name: Set Slack notify status
         if: failure()
         run: echo "NOTIFY_FAILURE=1" >> "$GITHUB_ENV"
 
-      # Notify Slack: on success (when image published) or on failure; only on push/workflow_dispatch/schedule, not on pull_request
       - name: Notify Slack
-        if: always() && github.event_name != 'pull_request' && (failure() || (success() && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && steps.distribution-changed.outputs.changed == 'true'))))
+        if: always() && github.event_name != 'pull_request' && failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.WH_SLACK_TEAM_LLS_CORE }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
@@ -294,7 +263,7 @@ jobs:
           fi
 
       - name: Output custom build information
-        if: contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
+        if: matrix.arch == 'amd64' && contains(fromJSON('["workflow_dispatch", "schedule"]'), github.event_name)
         env:
           LLS_COMMIT: ${{ env.LLAMA_STACK_COMMIT_SHA }}
         run: |
@@ -304,3 +273,94 @@ jobs:
           echo ""
           echo "You can pull this image using:"
           echo "docker pull $IMAGE_NAME:source-$LLS_COMMIT-$GITHUB_SHA"
+
+  publish:
+    needs: build-test
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && needs.build-test.outputs.distribution-changed == 'true')
+    runs-on: ubuntu-latest
+    env:
+      LLAMA_STACK_COMMIT_SHA: ${{ github.event.inputs.llama_stack_commit_sha || 'main' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        if: github.event_name == 'workflow_dispatch'
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          python-version: 3.12
+
+      - name: Generate Containerfile to build an image from an arbitrary llama-stack commit (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          LLAMA_STACK_VERSION: ${{ env.LLAMA_STACK_COMMIT_SHA }}
+        run: |
+          tmp_build_dir=$(mktemp -d)
+          git clone --filter=blob:none --no-checkout https://github.com/opendatahub-io/llama-stack.git "$tmp_build_dir"
+          cd "$tmp_build_dir"
+          git checkout "$LLAMA_STACK_VERSION"
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install --no-cache -e .
+          # now remove the install line from the Containerfile
+          cd -
+          python3 distribution/build.py
+          sed -i '/^RUN pip install --no-cache llama-stack==/d' distribution/Containerfile
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Publish multi-arch image to Quay.io
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          file: distribution/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ github.event_name == 'workflow_dispatch' && format('{0}:source-{1}-{2}', env.IMAGE_NAME, env.LLAMA_STACK_COMMIT_SHA, github.sha) || format('{0}:{1}{2}', env.IMAGE_NAME, github.sha, github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || (startsWith(github.ref, 'refs/heads/rhoai-v') && format(',{0}:{1}-latest', env.IMAGE_NAME, github.ref_name)) || '') }}
+          cache-from: |
+            type=gha,scope=build-amd64
+            type=gha,scope=build-arm64
+
+      - name: Set Slack notify status
+        if: failure()
+        run: echo "NOTIFY_FAILURE=1" >> "$GITHUB_ENV"
+
+      - name: Notify Slack
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.WH_SLACK_TEAM_LLS_CORE }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('source-{0}-{1}', env.LLAMA_STACK_COMMIT_SHA, github.sha) || github.sha }}
+          COMMIT_SHA: ${{ github.sha }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          COMMIT_SHA_SHORT="${COMMIT_SHA:0:7}"
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          if [[ "${NOTIFY_FAILURE:-0}" == "1" ]]; then
+            TEXT=$(printf '%s\n%s\n%s' \
+              ":failed: *Build failed for Llama Stack* - [${TIMESTAMP}]" \
+              "Commit: ${COMMIT_SHA_SHORT}" \
+              "<${WORKFLOW_URL}|View workflow run>")
+            bash .github/actions/notify-slack/notify.sh "$TEXT" "#d00000"
+          else
+            TEXT=$(printf '%s\n%s\n%s\n%s' \
+              ":greenchecked: *New image is available for Llama Stack* - [${TIMESTAMP}]" \
+              "Image: ${IMAGE_NAME}:${IMAGE_TAG}" \
+              "Commit: ${COMMIT_SHA_SHORT}" \
+              "<${WORKFLOW_URL}|View workflow run>")
+            bash .github/actions/notify-slack/notify.sh "$TEXT"
+          fi

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -169,48 +169,57 @@ main() {
   # Track failures
   failed_checks=()
 
-  # Build list of models to test based on available configuration
-  models_to_test=("$VLLM_INFERENCE_MODEL" "$EMBEDDING_MODEL")
-  inference_models_to_test=("$VLLM_INFERENCE_MODEL")
+  if [ "${SKIP_INFERENCE_TESTS:-false}" == "true" ]; then
+    echo "===> SKIP_INFERENCE_TESTS is set, running container health and PostgreSQL verification only"
+    echo "===> Skipping model list, inference, and data population checks (no vLLM available)"
 
-  # Only include Vertex AI models if VERTEX_AI_PROJECT is set
-  if [ -n "${VERTEX_AI_PROJECT:-}" ]; then
-    echo "===> VERTEX_AI_PROJECT is set, including Vertex AI models in tests"
-    models_to_test+=("$VERTEX_AI_INFERENCE_MODEL")
-    inference_models_to_test+=("$VERTEX_AI_INFERENCE_MODEL")
-  else
-    echo "===> VERTEX_AI_PROJECT is not set, skipping Vertex AI models"
-  fi
-
-  # Only include OpenAI models if OPENAI_API_KEY is set
-  if [ -n "${OPENAI_API_KEY:-}" ]; then
-    echo "===> OPENAI_API_KEY is set, including OpenAI models in tests"
-    models_to_test+=("$OPENAI_INFERENCE_MODEL")
-    inference_models_to_test+=("$OPENAI_INFERENCE_MODEL")
-  else
-    echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
-  fi
-
-  echo "===> Testing model list for all models..."
-  for model in "${models_to_test[@]}"; do
-    if ! test_model_list "$model"; then
-      failed_checks+=("model_list:$model")
+    if ! test_postgres_tables_exist; then
+      failed_checks+=("postgres:tables")
     fi
-  done
+  else
+    # Build list of models to test based on available configuration
+    models_to_test=("$VLLM_INFERENCE_MODEL" "$EMBEDDING_MODEL")
+    inference_models_to_test=("$VLLM_INFERENCE_MODEL")
 
-  echo "===> Testing inference for all models..."
-  for model in "${inference_models_to_test[@]}"; do
-    if ! test_model_openai_inference "$model"; then
-      failed_checks+=("inference:$model")
+    # Only include Vertex AI models if VERTEX_AI_PROJECT is set
+    if [ -n "${VERTEX_AI_PROJECT:-}" ]; then
+      echo "===> VERTEX_AI_PROJECT is set, including Vertex AI models in tests"
+      models_to_test+=("$VERTEX_AI_INFERENCE_MODEL")
+      inference_models_to_test+=("$VERTEX_AI_INFERENCE_MODEL")
+    else
+      echo "===> VERTEX_AI_PROJECT is not set, skipping Vertex AI models"
     fi
-  done
 
-  # Verify PostgreSQL tables and data
-  if ! test_postgres_tables_exist; then
-    failed_checks+=("postgres:tables")
-  fi
-  if ! test_postgres_populated; then
-    failed_checks+=("postgres:data")
+    # Only include OpenAI models if OPENAI_API_KEY is set
+    if [ -n "${OPENAI_API_KEY:-}" ]; then
+      echo "===> OPENAI_API_KEY is set, including OpenAI models in tests"
+      models_to_test+=("$OPENAI_INFERENCE_MODEL")
+      inference_models_to_test+=("$OPENAI_INFERENCE_MODEL")
+    else
+      echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
+    fi
+
+    echo "===> Testing model list for all models..."
+    for model in "${models_to_test[@]}"; do
+      if ! test_model_list "$model"; then
+        failed_checks+=("model_list:$model")
+      fi
+    done
+
+    echo "===> Testing inference for all models..."
+    for model in "${inference_models_to_test[@]}"; do
+      if ! test_model_openai_inference "$model"; then
+        failed_checks+=("inference:$model")
+      fi
+    done
+
+    # Verify PostgreSQL tables and data
+    if ! test_postgres_tables_exist; then
+      failed_checks+=("postgres:tables")
+    fi
+    if ! test_postgres_populated; then
+      failed_checks+=("postgres:data")
+    fi
   fi
 
   # Report results


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Uses a matrix strategy to run basic ARM64 tests on native ARM64 github runners. Similar to how builds are being done in the upstream llama-stack-k8s-operator repo now.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Follows up on https://github.com/opendatahub-io/llama-stack-distribution/pull/211

Closes RHAIENG-2790

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI pipeline for multi-architecture builds (amd64, arm64) with architecture-scoped caching and platform-specific artifacts
  * Added a separate conditional publish job and adjusted notification behavior to send failure-only alerts during build and always-report from publish

* **Tests**
  * Added SKIP_INFERENCE_TESTS option to skip inference-related checks while still verifying core PostgreSQL table existence and reporting failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->