### PR TITLE
fix(build): derive client install method from version format

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -37,7 +37,7 @@ PINNED_DEPENDENCIES = [
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}
-RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}"""
+RUN uv pip install --no-cache --no-deps {llama_stack_client_install}"""
 
 
 def get_llama_stack_install(llama_stack_version):
@@ -47,12 +47,17 @@ def get_llama_stack_install(llama_stack_version):
         if LLAMA_STACK_CLIENT_VERSION
         else llama_stack_version.split("+")[0]
     )
+    # source_install_command needs a git URL for branch names/SHAs, not a == pin
+    if "." not in llama_stack_client_version:
+        llama_stack_client_install = f"git+https://github.com/llamastack/llama-stack-client-python.git@{llama_stack_client_version}"
+    else:
+        llama_stack_client_install = f"llama-stack-client=={llama_stack_client_version}"
     # If the version is a commit SHA or a short commit SHA, we need to install from source
     if is_install_from_source(llama_stack_version):
         print(f"Installing llama-stack from source: {llama_stack_version}")
         return source_install_command.format(
             llama_stack_version=llama_stack_version,
-            llama_stack_client_version=llama_stack_client_version,
+            llama_stack_client_install=llama_stack_client_install,
         ).rstrip()
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes #260.

The nightly schedule build passes `LLAMA_STACK_VERSION=main` to `build.py`, which derives the client version as `"main".split("+")[0]` → `"main"`. This produces `llama-stack-client==main`, which is not a valid version specifier and fails the build.

When the derived client version is a branch name or commit SHA (no dots), install from git instead of pinning with `==`.

  ## Test Plan

  - Nightly schedule build should pass the Containerfile generation step
  - Push builds with `+rhai` versions are unchanged (`v0.5.0+rhai0` → `llama-stack-client==v0.5.0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build process to support dynamic version specifications for dependencies. The system now intelligently selects installation methods based on version format, improving flexibility for different release types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->