### PR TITLE
fix: rename meta-reference providers to builtin

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -50,7 +50,7 @@ jobs:
       # Deployment configuration - Llama Stack will support vLLM, Vertex AI, and OpenAI
       # Model names include provider prefixes for consistency
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/google/gemini-2.0-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-4o-mini
       EMBEDDING_MODEL: sentence-transformers/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -33,6 +33,7 @@ RUN uv pip install \
     fire \
     google-genai \
     httpx \
+    litellm \
     matplotlib \
     numpy \
     opentelemetry-exporter-otlp-proto-http \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -33,7 +33,6 @@ RUN uv pip install \
     fire \
     google-genai \
     httpx \
-    litellm \
     matplotlib \
     numpy \
     opentelemetry-exporter-otlp-proto-http \
@@ -66,7 +65,7 @@ RUN uv pip install \
     llama_stack_provider_trustyai_garak==0.3.1
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.6.0.1+rhai0
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.6.0.2+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.6.0
 RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -10,7 +10,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 
 | API | Provider | External? | Enabled by default? | How to enable |
 |-----|----------|-----------|---------------------|---------------|
-| agents | inline::meta-reference | No | ✅ | N/A |
+| agents | inline::builtin | No | ✅ | N/A |
 | batches | inline::reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.6.0.1+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.6.0.1+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.6.0.2+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.6.0.2+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,7 +15,7 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "v0.6.0.1+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "v0.6.0.2+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 LLAMA_STACK_CLIENT_VERSION = (
     None  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -135,13 +135,13 @@ providers:
         #   tenant_id: X-Tenant-Id
         #   team_id: X-Team-Id
   agents:
-  - provider_id: meta-reference
-    provider_type: inline::meta-reference
+  - provider_id: builtin
+    provider_type: inline::builtin
     config:
       persistence:
         agent_state:
           backend: kv_default
-          namespace: agents::meta_reference
+          namespace: agents::builtin
         responses:
           backend: sql_default
           table_name: agents_responses
@@ -227,7 +227,7 @@ providers:
     provider_type: remote::model-context-protocol
     config: {}
   files:
-  - provider_id: meta-reference-files
+  - provider_id: builtin-files
     provider_type: inline::localfs
     config:
       storage_dir: /opt/app-root/src/.llama/distributions/rh/files


### PR DESCRIPTION
## Summary

- Renames `meta-reference` provider references to `builtin` in distribution config and README
- Fixes CI failure caused by upstream [llamastack/llama-stack#5131](https://github.com/llamastack/llama-stack/pull/5131) which renamed all `meta-reference` providers to `builtin`

### What changed

- `provider_id: meta-reference` → `builtin` (agents)
- `provider_type: inline::meta-reference` → `inline::builtin` (agents)
- `namespace: agents::meta_reference` → `agents::builtin`
- `provider_id: meta-reference-files` → `builtin-files` (files)
- README table updated accordingly

### Root cause

The scheduled CI run [failed](https://github.com/opendatahub-io/llama-stack-distribution/actions/runs/23232011850) because `llama stack list-deps` could not find `inline::meta-reference` — it was renamed to `inline::builtin` upstream.

## Test plan

- [x] `llama stack list-deps distribution/config.yaml` passes against `llama-stack@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated provider configuration naming scheme for agents and files providers, transitioning from "meta-reference" to "builtin" naming convention.

* **Documentation**
  * Updated distribution documentation to reflect provider naming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->