### PR TITLE
chore: add RHOAI startup message to entrypoint

### DIFF
--- a/distribution/entrypoint.sh
+++ b/distribution/entrypoint.sh
@@ -21,4 +21,5 @@ if [ -n "$OTEL_SERVICE_NAME" ]; then
     llama stack run "$CONFIG" "$@"
 fi
 
+echo "HI o/, I'm running in RHOAI on openshift :-) "
 exec llama stack run "$CONFIG" "$@"


### PR DESCRIPTION
## Summary
- Adds friendly startup message to entrypoint.sh indicating the service is running in RHOAI on OpenShift

## Test plan
- [ ] Build and run container to verify message appears at startup
- [ ] Verify normal llama-stack operation is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)