### PR TITLE
chore: upgrade vLLM base image to v0.18.1

### DIFF
--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -2,7 +2,7 @@
 #
 # Reference: https://hub.docker.com/r/vllm/vllm-openai-cpu
 
-FROM vllm/vllm-openai-cpu:v0.18.0
+FROM vllm/vllm-openai-cpu:v0.18.1
 
 RUN pip install "huggingface-hub[cli]"
 

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -1,6 +1,6 @@
 # vLLM CPU Container Images
 
-This directory contains a Containerfile based on the official [vllm/vllm-openai-cpu](https://hub.docker.com/r/vllm/vllm-openai-cpu) image (v0.18.0) with pre-downloaded HuggingFace models baked in at build time.
+This directory contains a Containerfile based on the official [vllm/vllm-openai-cpu](https://hub.docker.com/r/vllm/vllm-openai-cpu) image with pre-downloaded HuggingFace models baked in at build time.
 
 ## Build Arguments
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to use the latest serving runtime version (0.18.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->