### PR TITLE
chore: update llama-stack to v0.7.1+rhaiv.0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -66,8 +66,8 @@ RUN uv pip install \
     llama_stack_provider_trustyai_garak==0.3.1
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@main
-RUN uv pip install --no-cache --no-deps 'llama-stack-api@git+https://github.com/opendatahub-io/llama-stack.git@main#subdirectory=src/llama_stack_api'
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.7.1+rhaiv.0
+RUN uv pip install --no-cache --no-deps llama-stack-client==v0.7.1
 RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 # Pre-cache tiktoken cl100k_base encoding to avoid runtime download

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [main](https://github.com/opendatahub-io/llama-stack/tree/main)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.7.1](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.7.1)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,7 +15,7 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "main"
+CURRENT_LLAMA_STACK_VERSION = "v0.7.1+rhaiv.0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 LLAMA_STACK_CLIENT_VERSION = (
     None  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version


### PR DESCRIPTION
## Summary

Update `CURRENT_LLAMA_STACK_VERSION` from `main` to `v0.7.1+rhaiv.0`

Regenerated distribution artifacts via pre-commit.

## Source

Tag: [`v0.7.1+rhaiv.0`](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.7.1+rhaiv.0)
Triggered by: [workflow run](https://github.com/opendatahub-io/llama-stack/actions/runs/24143988448)

## Test plan

- [ ] Review the generated `distribution/Containerfile` changes
- [ ] Verify the new tag exists in opendatahub-io/llama-stack
- [ ] Merge and confirm the distribution container build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated distribution image to use stable Llama Stack version 0.7.1 instead of development builds, ensuring more reproducible and consistent installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->