### PR TITLE
chore: update llama-stack to v0.7.1+rhaiv.1

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -66,8 +66,8 @@ RUN uv pip install \
     llama_stack_provider_trustyai_garak==0.3.1
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@main
-RUN uv pip install --no-cache --no-deps 'llama-stack-api@git+https://github.com/opendatahub-io/llama-stack.git@main#subdirectory=src/llama_stack_api'
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.7.1+rhaiv.1
+RUN uv pip install --no-cache --no-deps llama-stack-client==0.7.2
 RUN set -o pipefail && opentelemetry-bootstrap -a requirements | uv pip install --requirement -
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 # Pre-cache tiktoken cl100k_base encoding to avoid runtime download

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [main](https://github.com/opendatahub-io/llama-stack/tree/main)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.7.1](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.7.1)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,10 +15,10 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "main"
+CURRENT_LLAMA_STACK_VERSION = "v0.7.1+rhaiv.1"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 LLAMA_STACK_CLIENT_VERSION = (
-    None  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
+    "0.7.2"  # Explicit version; set to None to auto-derive from LLAMA_STACK_VERSION
 )
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -16,6 +16,7 @@ function start_and_wait_for_llama_stack_container {
     --pull=never
     --net=host
     -p 8321:8321
+    --env "EMBEDDING_MODEL=$EMBEDDING_MODEL"
     --env "VLLM_URL=$VLLM_URL"
     --env "VLLM_EMBEDDING_URL=$VLLM_EMBEDDING_URL"
     --env "TRUSTYAI_LMEVAL_USE_K8S=False"


### PR DESCRIPTION
## Summary

Update `CURRENT_LLAMA_STACK_VERSION` from `main` to `v0.7.1+rhaiv.1`

Regenerated distribution artifacts via pre-commit.

## Source

Tag: [`v0.7.1+rhaiv.1`](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.7.1+rhaiv.1)
Triggered by: [workflow run](https://github.com/opendatahub-io/llama-stack/actions/runs/24148289864)

## Test plan

- [ ] Review the generated `distribution/Containerfile` changes
- [ ] Verify the new tag exists in opendatahub-io/llama-stack
- [ ] Merge and confirm the distribution container build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned runtime components to specific releases (v0.7.1+rhaiv.1 and client 0.7.2) for more reproducible, deterministic installs.
  * Switched client installation to a fixed package release instead of a moving branch/source fallback; build defaults adjusted to use these pinned versions.

* **Documentation**
  * Updated distribution README to reference the v0.7.1+rhaiv.1 release.

* **Tests**
  * Test harness now forwards the EMBEDDING_MODEL environment variable into the test container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->