### PR TITLE
fix(ci): restore EMBEDDING_MODEL env var in smoke test container

### DIFF
--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -16,6 +16,7 @@ function start_and_wait_for_llama_stack_container {
     --pull=never
     --net=host
     -p 8321:8321
+    --env "EMBEDDING_MODEL=$EMBEDDING_MODEL"
     --env "VLLM_URL=$VLLM_URL"
     --env "VLLM_EMBEDDING_URL=$VLLM_EMBEDDING_URL"
     --env "TRUSTYAI_LMEVAL_USE_K8S=False"


### PR DESCRIPTION
## Summary

- Restores `--env "EMBEDDING_MODEL=$EMBEDDING_MODEL"` to the smoke test docker args, removed in #330
- Without this env var, `config.yaml` resolves `model_id: ${env.EMBEDDING_MODEL:=}` to empty string inside the container, dropping the model entry entirely (`registered_resources: models: []`)
- This causes the `model_list:vllm-embedding/nomic-embed-text-v1-5` smoke test check to fail on both amd64 and arm64

## Test plan

- [ ] CI smoke test passes on both amd64 and arm64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved smoke test environment configuration for embedding model validation during container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->