### PR TITLE
ci: trigger Tekton pipelines on rhoai-* branches

### DIFF
--- a/.tekton/odh-llama-stack-core-pull-request.yaml
+++ b/.tekton/odh-llama-stack-core-pull-request.yaml
@@ -8,8 +8,9 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "distribution/**".pathChanged() || ".tekton/odh-llama-stack-core-pull-request.yaml".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      (target_branch == "main" || target_branch.startsWith("rhoai-")) &&
+      ( "distribution/**".pathChanged() || ".tekton/odh-llama-stack-core-pull-request.yaml".pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/odh-llama-stack-core-push.yaml
+++ b/.tekton/odh-llama-stack-core-push.yaml
@@ -7,8 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "distribution/**".pathChanged() || ".tekton/odh-llama-stack-core-push.yaml".pathChanged()
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      (target_branch == "main" || target_branch.startsWith("rhoai-")) &&
+      ( "distribution/**".pathChanged() || ".tekton/odh-llama-stack-core-push.yaml".pathChanged()
       )
   creationTimestamp: null
   labels:
@@ -24,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/llama-stack:odh-stable
+    value: "quay.io/opendatahub/llama-stack:{{ cel: pac.target_branch == 'main' ? 'odh-nightly' : 'odh-stable' }}"
   - name: dockerfile
     value: distribution/Containerfile
   - name: path-context


### PR DESCRIPTION
## Summary
- Update PaC CEL expressions in both PR and push pipelines to also trigger on `rhoai-*` branches
- Use a CEL ternary in the push pipeline output-image to tag `main` builds as `odh-nightly` and `rhoai-*` builds as `odh-stable`

## Test plan
- [ ] Verify PR pipeline triggers on a PR targeting a `rhoai-*` branch
- [ ] Verify push pipeline tags `main` builds as `odh-nightly`
- [ ] Verify push pipeline tags `rhoai-*` builds as `odh-stable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline triggering to support feature branches with "rhoai-" prefix in addition to the main branch
  * Implemented dynamic container image tagging strategy based on target branch for automated builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->