### PR TITLE
feat: allow vLLM providers to automatically refresh models

### DIFF
--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -20,6 +20,7 @@ providers:
       max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_TLS_VERIFY:=true}
+      refresh_models: ${env.VLLM_REFRESH_MODELS:=false}
   - provider_id: ${env.VLLM_EMBEDDING_URL:+vllm-embedding}
     provider_type: remote::vllm
     config:
@@ -27,6 +28,7 @@ providers:
       max_tokens: ${env.VLLM_EMBEDDING_MAX_TOKENS:=4096}
       api_token: ${env.VLLM_EMBEDDING_API_TOKEN:=fake}
       tls_verify: ${env.VLLM_EMBEDDING_TLS_VERIFY:=true}
+      refresh_models: ${env.VLLM_EMBEDDING_REFRESH_MODELS:=false}
   - provider_id: ${env.AWS_BEARER_TOKEN_BEDROCK:+bedrock}
     provider_type: remote::bedrock
     config:


### PR DESCRIPTION
# What does this PR do?
the remote::vllm provider allows for automatic refresh of the model registry - without this, Llama Stack does not always detect new models available to the server

default value of "false" for consistency with previous behavior

more details: https://llamastack.github.io/docs/providers/inference/remote_vllm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model refresh settings for VLLM inference and embedding providers, allowing users to control automatic model refresh behavior via environment variables with defaults disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->