### PR TITLE
ci: add daily schedule to showroom test workflow

### DIFF
--- a/.github/workflows/test-pr-in-showroom.yml
+++ b/.github/workflows/test-pr-in-showroom.yml
@@ -89,6 +89,10 @@ jobs:
               echo "Invalid PR_NUMBER"
               exit 1
             fi
+            if ! [[ "$PR_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+              echo "Invalid PR_SHA"
+              exit 1
+            fi
             TAG="pr-${PR_NUMBER}-${PR_SHA}"
           else
             SHORT_SHA="${PUSH_SHA:0:12}"
@@ -196,8 +200,8 @@ jobs:
             echo ""
             echo "## Test Results"
             if [ "$JOB_STATUS" = "success" ]; then
-              echo "All tests passed."
+              echo "✅ All tests passed successfully!"
             else
-              echo "Tests failed. Check the logs above for details."
+              echo "❌ Tests failed. Check the logs above for details."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-pr-in-showroom.yml
+++ b/.github/workflows/test-pr-in-showroom.yml
@@ -1,6 +1,8 @@
 name: Test PR in Showroom
 
 on:
+  schedule:
+    - cron: '0 8 * * *'  # daily at 08:00 UTC
   workflow_dispatch:
     inputs:
       pr_number:
@@ -28,6 +30,7 @@ jobs:
 
     steps:
       - name: Get PR information
+        if: inputs.pr_number != ''
         id: pr-info
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -56,6 +59,7 @@ jobs:
             console.log(`  Repo: ${pr.data.head.repo.full_name}`);
 
       - name: Checkout PR code
+        if: inputs.pr_number != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ steps.pr-info.outputs.repo }}
@@ -63,21 +67,33 @@ jobs:
           path: llama-stack-distribution
           persist-credentials: false
 
+      - name: Checkout pushed code
+        if: inputs.pr_number == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          path: llama-stack-distribution
+
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
 
-      - name: Build image from PR
+      - name: Build image
         id: build
         working-directory: llama-stack-distribution
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_SHA: ${{ steps.pr-info.outputs.sha }}
+          PUSH_SHA: ${{ github.sha }}
         run: |
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "Invalid PR_NUMBER"
-            exit 1
+          if [ -n "$PR_NUMBER" ]; then
+            if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "Invalid PR_NUMBER"
+              exit 1
+            fi
+            TAG="pr-${PR_NUMBER}-${PR_SHA}"
+          else
+            SHORT_SHA="${PUSH_SHA:0:12}"
+            TAG="push-${SHORT_SHA}"
           fi
-          TAG="pr-${PR_NUMBER}-${PR_SHA}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Building image: llama-stack-test:$TAG"
 
@@ -88,7 +104,7 @@ jobs:
 
       - name: Setup CI environment
         id: setup
-        uses: derekhiggins/llama-stack-showroom@036ca9802bbe245d59bbe4a3d703f37c82cf692f  # main as of 2026-03-24
+        uses: derekhiggins/llama-stack-showroom@fad3dfe273d55357107929e36eb031706456fe88  # main as of 2026-04-23
         with:
           catalog_image: ${{ inputs.catalog_image }}
           llama_stack_image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-operator/llama-stack-test:${{ steps.build.outputs.tag }}"
@@ -161,21 +177,27 @@ jobs:
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_SHA: ${{ steps.pr-info.outputs.sha }}
+          PUSH_SHA: ${{ github.sha }}
           IMAGE_TAG: ${{ steps.build.outputs.tag }}
           JOB_STATUS: ${{ job.status }}
         run: |
           {
-            echo "# Test PR in Showroom - Summary"
+            echo "# Test in Showroom - Summary"
             echo ""
             echo "## Build Information"
-            echo "- **PR Number**: #${PR_NUMBER}"
-            echo "- **Commit SHA**: ${PR_SHA}"
+            if [ -n "$PR_NUMBER" ]; then
+              echo "- **PR Number**: #${PR_NUMBER}"
+              echo "- **Commit SHA**: ${PR_SHA}"
+            else
+              echo "- **Trigger**: push"
+              echo "- **Commit SHA**: ${PUSH_SHA}"
+            fi
             echo "- **Image Tag**: \`${IMAGE_TAG}\`"
             echo ""
             echo "## Test Results"
             if [ "$JOB_STATUS" = "success" ]; then
-              echo "✅ All tests passed successfully!"
+              echo "All tests passed."
             else
-              echo "❌ Tests failed. Check the logs above for details."
+              echo "Tests failed. Check the logs above for details."
             fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add daily schedule trigger (08:00 UTC) to the showroom test workflow
- Make PR-specific steps conditional so scheduled runs build and test from the default branch
- Update showroom action to latest main (fad3dfe)

## Test plan
- [x] Verified workflow runs end-to-end via push trigger on test branch
- [ ] Confirm scheduled trigger fires at 08:00 UTC
- [ ] Verify workflow_dispatch with PR number still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added daily scheduled runs and enabled push-triggered builds alongside PR runs.
  * PR-specific steps now run only for PRs; push runs use a separate checkout and flow.
  * Standardized image tagging: distinct PR tags and push tags, with push SHA propagated through build and summaries.
  * Improved job summary to show PR or push details and standardized success/failure messaging.
  * Updated pinned third-party action reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->