### PR TITLE
chore: upgrade vLLM CPU image to 0.19.1

### DIFF
--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -2,7 +2,7 @@
 #
 # Reference: https://hub.docker.com/r/vllm/vllm-openai-cpu
 
-FROM vllm/vllm-openai-cpu:v0.19.0
+FROM vllm/vllm-openai-cpu:v0.19.1
 
 RUN pip install "huggingface-hub[cli]"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image to latest version (v0.19.1) for container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->