### PR TITLE
feat: add remote::gemini provider to distro config

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -145,7 +145,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ] || [ "${{ github.secret_source }}" = "Dependabot" ]; then
               echo "::warning::Fork/Dependabot PR — unsetting all provider credentials"
-              { echo "VERTEX_AI_PROJECT="; echo "GCP_WORKLOAD_IDENTITY_PROVIDER="; echo "OPENAI_API_KEY="; echo "GEMINI_API_KEY="; } >> "$GITHUB_ENV"
+              { echo "VERTEX_AI_PROJECT="; echo "GCP_WORKLOAD_IDENTITY_PROVIDER="; echo "OPENAI_API_KEY="; echo "GEMINI_API_KEY="; echo "ENABLE_GEMINI="; } >> "$GITHUB_ENV"
               exit 0
             fi
           fi
@@ -169,7 +169,9 @@ jobs:
               "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY")
             if [ "$status" != "200" ]; then
               echo "::warning::Gemini API returned HTTP $status, skipping Gemini tests"
-              echo "GEMINI_API_KEY=" >> "$GITHUB_ENV"
+              { echo "GEMINI_API_KEY="; echo "ENABLE_GEMINI="; } >> "$GITHUB_ENV"
+            else
+              echo "ENABLE_GEMINI=1" >> "$GITHUB_ENV"
             fi
           fi
 

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -61,10 +61,12 @@ jobs:
       VERTEX_AI_PROJECT: ${{ secrets.VERTEX_AI_PROJECT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Model names - set defaults, overridden by MaaS configuration step
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
       VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.0-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-5-nano
+      GEMINI_INFERENCE_MODEL: gemini/gemini-2.0-flash
       EMBEDDING_MODEL: vllm-embedding/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1
       VLLM_EMBEDDING_URL: http://localhost:8001/v1
@@ -143,7 +145,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ github.event.pull_request.head.repo.fork }}" = "true" ] || [ "${{ github.secret_source }}" = "Dependabot" ]; then
               echo "::warning::Fork/Dependabot PR — unsetting all provider credentials"
-              { echo "VERTEX_AI_PROJECT="; echo "GCP_WORKLOAD_IDENTITY_PROVIDER="; echo "OPENAI_API_KEY="; } >> "$GITHUB_ENV"
+              { echo "VERTEX_AI_PROJECT="; echo "GCP_WORKLOAD_IDENTITY_PROVIDER="; echo "OPENAI_API_KEY="; echo "GEMINI_API_KEY="; } >> "$GITHUB_ENV"
               exit 0
             fi
           fi
@@ -158,6 +160,16 @@ jobs:
             if [ "$status" != "200" ]; then
               echo "::warning::OpenAI API returned HTTP $status, skipping OpenAI tests"
               echo "OPENAI_API_KEY=" >> "$GITHUB_ENV"
+            fi
+          fi
+
+          # Gemini: validate key with a lightweight call
+          if [ -n "$GEMINI_API_KEY" ]; then
+            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
+              "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY")
+            if [ "$status" != "200" ]; then
+              echo "::warning::Gemini API returned HTTP $status, skipping Gemini tests"
+              echo "GEMINI_API_KEY=" >> "$GITHUB_ENV"
             fi
           fi
 

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -16,6 +16,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | inline::sentence-transformers | No | Dependency only* | Requires a custom `config.yaml` |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
 | inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
+| inference | remote::gemini | No | ❌ | Set the `GEMINI_API_KEY` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -17,6 +17,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | inline::sentence-transformers | No | Dependency only* | Requires a custom `config.yaml` |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
 | inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
+| inference | remote::gemini | No | ❌ | Set the `GEMINI_API_KEY` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -17,8 +17,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | inline::sentence-transformers | No | Dependency only* | Requires a custom `config.yaml` |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
 | inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
-| inference | remote::gemini | No | ❌ | Set the `GEMINI_API_KEY` environment variable |
-| inference | remote::gemini | No | ❌ | Set the `GEMINI_ACCESS_TOKEN` environment variable |
+| inference | remote::gemini | No | ❌ | Set the `ENABLE_GEMINI` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -18,6 +18,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
 | inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
 | inference | remote::gemini | No | ❌ | Set the `GEMINI_API_KEY` environment variable |
+| inference | remote::gemini | No | ❌ | Set the `GEMINI_ACCESS_TOKEN` environment variable |
 | inference | remote::openai | No | ❌ | Set the `OPENAI_API_KEY` environment variable |
 | inference | remote::vertexai | No | ❌ | Set the `VERTEX_AI_PROJECT` environment variable |
 | inference | remote::vllm | No | ❌ | Set the `VLLM_URL` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -56,6 +56,12 @@ providers:
     config:
       api_key: ${env.OPENAI_API_KEY:=}
       base_url: ${env.OPENAI_BASE_URL:=https://api.openai.com/v1}
+  - provider_id: ${env.GEMINI_API_KEY:+gemini}
+    provider_type: remote::gemini
+    config:
+      api_key: ${env.GEMINI_API_KEY:=}
+      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
+      project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:
   - provider_id: milvus
     provider_type: inline::milvus

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -56,13 +56,10 @@ providers:
     config:
       api_key: ${env.OPENAI_API_KEY:=}
       base_url: ${env.OPENAI_BASE_URL:=https://api.openai.com/v1}
-  - provider_id: ${env.GEMINI_API_KEY:+gemini}
+  - provider_id: ${env.ENABLE_GEMINI:+gemini}
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-  - provider_id: ${env.GEMINI_ACCESS_TOKEN:+gemini}
-    provider_type: remote::gemini
-    config:
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -60,6 +60,9 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
+  - provider_id: ${env.GEMINI_ACCESS_TOKEN:+gemini}
+    provider_type: remote::gemini
+    config:
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -60,6 +60,12 @@ providers:
     config:
       api_key: ${env.OPENAI_API_KEY:=}
       base_url: ${env.OPENAI_BASE_URL:=https://api.openai.com/v1}
+  - provider_id: ${env.GEMINI_API_KEY:+gemini}
+    provider_type: remote::gemini
+    config:
+      api_key: ${env.GEMINI_API_KEY:=}
+      access_token: ${env.GEMINI_ACCESS_TOKEN:=}
+      project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:
   - provider_id: ${env.MILVUS_ENDPOINT:+milvus-remote}
     provider_type: remote::milvus

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -60,13 +60,10 @@ providers:
     config:
       api_key: ${env.OPENAI_API_KEY:=}
       base_url: ${env.OPENAI_BASE_URL:=https://api.openai.com/v1}
-  - provider_id: ${env.GEMINI_API_KEY:+gemini}
+  - provider_id: ${env.ENABLE_GEMINI:+gemini}
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
-  - provider_id: ${env.GEMINI_ACCESS_TOKEN:+gemini}
-    provider_type: remote::gemini
-    config:
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -64,6 +64,9 @@ providers:
     provider_type: remote::gemini
     config:
       api_key: ${env.GEMINI_API_KEY:=}
+  - provider_id: ${env.GEMINI_ACCESS_TOKEN:+gemini}
+    provider_type: remote::gemini
+    config:
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
   vector_io:

--- a/docs/google-walkthrough.md
+++ b/docs/google-walkthrough.md
@@ -103,18 +103,19 @@ curl -X POST \
 
 OGX has both a ["Gemini"](https://ogx-ai.github.io/docs/next/providers/inference/remote_gemini) and "Vertex AI" provider. They are completely different APIs.
 
-The Gemini provider supports two authentication methods (`GEMINI_API_KEY` or `GEMINI_ACCESS_TOKEN`, but not both):
+The Gemini provider is enabled by setting `ENABLE_GEMINI=1`. It supports two authentication methods (`GEMINI_API_KEY` or `GEMINI_ACCESS_TOKEN` + `GEMINI_AI_PROJECT`, but not both):
 
 | Method | Env vars | Use case |
 |---|---|---|
-| **API key** | `GEMINI_API_KEY` | Keys from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key). Sent as a `?key=` query parameter. |
-| **OAuth/ADC** | `GEMINI_ACCESS_TOKEN` + `GEMINI_AI_PROJECT` | Short-lived tokens from `gcloud` SSO. Sent as `Authorization: Bearer` header. |
+| **API key** | `ENABLE_GEMINI` + `GEMINI_API_KEY` | Keys from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key). Sent as a `?key=` query parameter. |
+| **OAuth/ADC** | `ENABLE_GEMINI` + `GEMINI_ACCESS_TOKEN` + `GEMINI_AI_PROJECT` | Short-lived tokens from `gcloud` SSO. Sent as `Authorization: Bearer` header. |
 
 ### Running Gemini with OGX
 
 **API key path** — acquire a key from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key):
 
 ```bash
+export ENABLE_GEMINI=1
 export GEMINI_API_KEY=<your-api-key>
 ```
 
@@ -125,6 +126,7 @@ export CLOUDSDK_CONFIG="/tmp/gcloud"
 
 gcloud auth application-default login --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
 
+export ENABLE_GEMINI=1
 export GEMINI_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
 # Choose "aaet-dev" if you are on the core OGX team.
 export GEMINI_AI_PROJECT=aaet-dev

--- a/docs/google-walkthrough.md
+++ b/docs/google-walkthrough.md
@@ -101,13 +101,50 @@ curl -X POST \
 
 ## Gemini examples
 
-OGX has both a ["Gemini"](https://ogx-ai.github.io/docs/next/providers/inference/remote_gemini) and "Vertex AI" provider. They are completely different APIs. The Gemini provider uses the `GEMINI_API_KEY` env var.
+OGX has both a ["Gemini"](https://ogx-ai.github.io/docs/next/providers/inference/remote_gemini) and "Vertex AI" provider. They are completely different APIs.
 
-There are multiple ways to acquire a Gemini API key. Many developers acquire a key with [Google's web UI](https://ai.google.dev/gemini-api/docs/api-key). In this walkthrough, we will use the `gcloud` CLI with single-sign-on to acquire a short-lived OAuth access token (and assign it to `GEMINI_API_KEY`).
+The Gemini provider supports two authentication methods:
+
+| Method | Env vars | Use case |
+|---|---|---|
+| **API key** | `GEMINI_API_KEY` | Keys from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key). Sent as a `?key=` query parameter. |
+| **OAuth/ADC** | `GEMINI_API_KEY=unused` + `GEMINI_ACCESS_TOKEN` + (optional) `GEMINI_AI_PROJECT` | Short-lived tokens from `gcloud` SSO. Sent as `Authorization: Bearer` header. |
+
+> **Why set `GEMINI_API_KEY=unused` for OAuth?** The OGX distribution activates the Gemini provider only when `GEMINI_API_KEY` is non-empty. Setting it to any non-empty value (e.g. `unused`) activates the provider; the upstream code then uses `GEMINI_ACCESS_TOKEN` for Bearer auth when it is present, ignoring the `api_key` value.
+
+### Running Gemini with OGX
+
+**API key path** — acquire a key from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key):
+
+```bash
+export GEMINI_API_KEY=<your-api-key>
+```
+
+**OAuth/ADC path** — use `gcloud` SSO to get a short-lived access token:
+
+```bash
+export CLOUDSDK_CONFIG="/tmp/gcloud"
+
+gcloud auth application-default login --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
+
+export GEMINI_API_KEY=unused
+export GEMINI_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
+# Choose "aaet-dev" if you are on the core OGX team.
+export GEMINI_AI_PROJECT=aaet-dev
+```
+
+With either method, start OGX and verify Gemini models are available:
+
+```bash
+ogx stack run starter
+curl -s http://localhost:8321/v1/models | jq '.data[].id' | grep gemini
+```
 
 ### Testing Gemini REST API with curl
 
-Again, use the temporary location for Google auth:
+For lower-level debugging outside of OGX, you can call the Gemini REST API directly.
+
+Use the temporary location for Google auth:
 
 ```bash
 export CLOUDSDK_CONFIG="/tmp/gcloud"
@@ -119,10 +156,10 @@ Retrieve an Application Default Credential (ADC) that has the `generative-langua
 gcloud auth application-default login --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
 ```
 
-Obtain a short-lived OAuth access token from this ADC and assign it to `GEMINI_API_KEY`:
+Obtain a short-lived OAuth access token:
 
 ```bash
-GEMINI_API_KEY=$(gcloud auth application-default print-access-token)
+GEMINI_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
 ```
 
 Making a chat request:
@@ -133,7 +170,7 @@ GEMINI_AI_PROJECT=aaet-dev
 
 curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent" \
   -H 'Content-Type: application/json' \
-  -H "Authorization: Bearer $GEMINI_API_KEY" \
+  -H "Authorization: Bearer $GEMINI_ACCESS_TOKEN" \
   -H "x-goog-user-project: $GEMINI_AI_PROJECT" \
   -X POST -d '{
     "contents": [
@@ -153,7 +190,7 @@ curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:g
 For troubleshooting, verify the oauth scopes for your access token, like so:
 
 ```bash
-$ curl https://oauth2.googleapis.com/tokeninfo?access_token=$GEMINI_API_KEY
+$ curl https://oauth2.googleapis.com/tokeninfo?access_token=$GEMINI_ACCESS_TOKEN
 {
   "azp": "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com",
   "aud": "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com",

--- a/docs/google-walkthrough.md
+++ b/docs/google-walkthrough.md
@@ -103,14 +103,12 @@ curl -X POST \
 
 OGX has both a ["Gemini"](https://ogx-ai.github.io/docs/next/providers/inference/remote_gemini) and "Vertex AI" provider. They are completely different APIs.
 
-The Gemini provider supports two authentication methods:
+The Gemini provider supports two authentication methods (`GEMINI_API_KEY` or `GEMINI_ACCESS_TOKEN`, but not both):
 
 | Method | Env vars | Use case |
 |---|---|---|
 | **API key** | `GEMINI_API_KEY` | Keys from [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key). Sent as a `?key=` query parameter. |
-| **OAuth/ADC** | `GEMINI_API_KEY=unused` + `GEMINI_ACCESS_TOKEN` + (optional) `GEMINI_AI_PROJECT` | Short-lived tokens from `gcloud` SSO. Sent as `Authorization: Bearer` header. |
-
-> **Why set `GEMINI_API_KEY=unused` for OAuth?** The OGX distribution activates the Gemini provider only when `GEMINI_API_KEY` is non-empty. Setting it to any non-empty value (e.g. `unused`) activates the provider; the upstream code then uses `GEMINI_ACCESS_TOKEN` for Bearer auth when it is present, ignoring the `api_key` value.
+| **OAuth/ADC** | `GEMINI_ACCESS_TOKEN` + `GEMINI_AI_PROJECT` | Short-lived tokens from `gcloud` SSO. Sent as `Authorization: Bearer` header. |
 
 ### Running Gemini with OGX
 
@@ -127,7 +125,6 @@ export CLOUDSDK_CONFIG="/tmp/gcloud"
 
 gcloud auth application-default login --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
 
-export GEMINI_API_KEY=unused
 export GEMINI_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
 # Choose "aaet-dev" if you are on the core OGX team.
 export GEMINI_AI_PROJECT=aaet-dev

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -103,7 +103,6 @@ function main() {
     echo "  VERTEX_AI_PROJECT: ${VERTEX_AI_PROJECT:-<not set>}"
     echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:+<set>}"
     echo "  GEMINI_API_KEY: ${GEMINI_API_KEY:+<set>}"
-    echo "  GEMINI_ACCESS_TOKEN: ${GEMINI_ACCESS_TOKEN:+<set>}"
 
     clone_ogx
 
@@ -127,12 +126,12 @@ function main() {
         echo "OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY or GEMINI_ACCESS_TOKEN is set
-    if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
-        echo "Gemini credentials set, including Gemini models in tests"
+    # Only include Gemini models if GEMINI_API_KEY is set
+    if [ -n "${GEMINI_API_KEY:-}" ]; then
+        echo "GEMINI_API_KEY is set, including Gemini models in tests"
         models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-        echo "Gemini credentials not set, skipping Gemini models"
+        echo "GEMINI_API_KEY is not set, skipping Gemini models"
     fi
 
     for model in "${models_to_test[@]}"; do

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -98,9 +98,11 @@ function main() {
     echo "  VLLM_INFERENCE_MODEL: $VLLM_INFERENCE_MODEL"
     echo "  VERTEX_AI_INFERENCE_MODEL: $VERTEX_AI_INFERENCE_MODEL"
     echo "  OPENAI_INFERENCE_MODEL: $OPENAI_INFERENCE_MODEL"
+    echo "  GEMINI_INFERENCE_MODEL: ${GEMINI_INFERENCE_MODEL:-<not set>}"
     echo "  EMBEDDING_MODEL: $EMBEDDING_MODEL"
     echo "  VERTEX_AI_PROJECT: ${VERTEX_AI_PROJECT:-<not set>}"
     echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:+<set>}"
+    echo "  GEMINI_API_KEY: ${GEMINI_API_KEY:+<set>}"
 
     clone_ogx
 
@@ -122,6 +124,14 @@ function main() {
         models_to_test+=("$OPENAI_INFERENCE_MODEL")
     else
         echo "OPENAI_API_KEY is not set, skipping OpenAI models"
+    fi
+
+    # Only include Gemini models if GEMINI_API_KEY is set
+    if [ -n "${GEMINI_API_KEY:-}" ]; then
+        echo "GEMINI_API_KEY is set, including Gemini models in tests"
+        models_to_test+=("$GEMINI_INFERENCE_MODEL")
+    else
+        echo "GEMINI_API_KEY is not set, skipping Gemini models"
     fi
 
     for model in "${models_to_test[@]}"; do

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -127,12 +127,12 @@ function main() {
         echo "OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY is set
-    if [ -n "${GEMINI_API_KEY:-}" ]; then
-        echo "GEMINI_API_KEY is set, including Gemini models in tests"
+    # Only include Gemini models if GEMINI_API_KEY or GEMINI_ACCESS_TOKEN is set
+    if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
+        echo "Gemini credentials set, including Gemini models in tests"
         models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-        echo "GEMINI_API_KEY is not set, skipping Gemini models"
+        echo "Gemini credentials not set, skipping Gemini models"
     fi
 
     for model in "${models_to_test[@]}"; do

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -103,6 +103,7 @@ function main() {
     echo "  VERTEX_AI_PROJECT: ${VERTEX_AI_PROJECT:-<not set>}"
     echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:+<set>}"
     echo "  GEMINI_API_KEY: ${GEMINI_API_KEY:+<set>}"
+    echo "  GEMINI_ACCESS_TOKEN: ${GEMINI_ACCESS_TOKEN:+<set>}"
 
     clone_ogx
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -60,13 +60,10 @@ function start_and_wait_for_ogx_container {
 
   # Only add Gemini configuration if GEMINI_API_KEY is set
   if [ -n "${GEMINI_API_KEY:-}" ]; then
-    docker_args+=(--env "GEMINI_API_KEY=$GEMINI_API_KEY")
-  fi
-  if [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
-    docker_args+=(--env "GEMINI_ACCESS_TOKEN=$GEMINI_ACCESS_TOKEN")
-  fi
-  if [ -n "${GEMINI_AI_PROJECT:-}" ]; then
-    docker_args+=(--env "GEMINI_AI_PROJECT=$GEMINI_AI_PROJECT")
+    docker_args+=(
+      --env "ENABLE_GEMINI=1"
+      --env "GEMINI_API_KEY=$GEMINI_API_KEY"
+    )
   fi
 
   docker_args+=(--name ogx "$IMAGE_NAME:${IMAGE_TAG:-$GITHUB_SHA}")
@@ -253,13 +250,13 @@ main() {
       echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY or GEMINI_ACCESS_TOKEN is set
-    if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
-      echo "===> Gemini credentials set, including Gemini models in tests"
+    # Only include Gemini models if GEMINI_API_KEY is set
+    if [ -n "${GEMINI_API_KEY:-}" ]; then
+      echo "===> GEMINI_API_KEY is set, including Gemini models in tests"
       models_to_test+=("$GEMINI_INFERENCE_MODEL")
       inference_models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-      echo "===> Gemini credentials not set, skipping Gemini models"
+      echo "===> GEMINI_API_KEY is not set, skipping Gemini models"
     fi
 
     echo "===> Testing model list for all models..."

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -58,6 +58,11 @@ function start_and_wait_for_ogx_container {
     docker_args+=(--env "OPENAI_API_KEY=$OPENAI_API_KEY")
   fi
 
+  # Only add Gemini configuration if GEMINI_API_KEY is set
+  if [ -n "${GEMINI_API_KEY:-}" ]; then
+    docker_args+=(--env "GEMINI_API_KEY=$GEMINI_API_KEY")
+  fi
+
   docker_args+=(--name ogx "$IMAGE_NAME:${IMAGE_TAG:-$GITHUB_SHA}")
 
   # Start ogx
@@ -240,6 +245,15 @@ main() {
       inference_models_to_test+=("$OPENAI_INFERENCE_MODEL")
     else
       echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
+    fi
+
+    # Only include Gemini models if GEMINI_API_KEY is set
+    if [ -n "${GEMINI_API_KEY:-}" ]; then
+      echo "===> GEMINI_API_KEY is set, including Gemini models in tests"
+      models_to_test+=("$GEMINI_INFERENCE_MODEL")
+      inference_models_to_test+=("$GEMINI_INFERENCE_MODEL")
+    else
+      echo "===> GEMINI_API_KEY is not set, skipping Gemini models"
     fi
 
     echo "===> Testing model list for all models..."

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -62,6 +62,12 @@ function start_and_wait_for_ogx_container {
   if [ -n "${GEMINI_API_KEY:-}" ]; then
     docker_args+=(--env "GEMINI_API_KEY=$GEMINI_API_KEY")
   fi
+  if [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
+    docker_args+=(--env "GEMINI_ACCESS_TOKEN=$GEMINI_ACCESS_TOKEN")
+  fi
+  if [ -n "${GEMINI_AI_PROJECT:-}" ]; then
+    docker_args+=(--env "GEMINI_AI_PROJECT=$GEMINI_AI_PROJECT")
+  fi
 
   docker_args+=(--name ogx "$IMAGE_NAME:${IMAGE_TAG:-$GITHUB_SHA}")
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -253,13 +253,13 @@ main() {
       echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY is set
-    if [ -n "${GEMINI_API_KEY:-}" ]; then
-      echo "===> GEMINI_API_KEY is set, including Gemini models in tests"
+    # Only include Gemini models if GEMINI_API_KEY or GEMINI_ACCESS_TOKEN is set
+    if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GEMINI_ACCESS_TOKEN:-}" ]; then
+      echo "===> Gemini credentials set, including Gemini models in tests"
       models_to_test+=("$GEMINI_INFERENCE_MODEL")
       inference_models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-      echo "===> GEMINI_API_KEY is not set, skipping Gemini models"
+      echo "===> Gemini credentials not set, skipping Gemini models"
     fi
 
     echo "===> Testing model list for all models..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini as a disabled-by-default inference provider; enable via ENABLE_GEMINI and provide GEMINI_API_KEY or GEMINI_ACCESS_TOKEN (optional GEMINI_AI_PROJECT).

* **Documentation**
  * Walkthrough updated for two Gemini auth modes (API key vs OAuth/ADC), env-var mappings, and REST/curl debugging with short-lived access tokens.

* **CI / Tests**
  * CI and test runners validate Gemini credentials, surface status in logs, and conditionally include or skip Gemini tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->