### PR TITLE
feat(api)!: remove safety/shields API

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -52,8 +52,6 @@ RUN uv pip install \
     tqdm \
     transformers \
     uvicorn
-RUN uv pip install \
-    llama_stack_provider_trustyai_fms==0.4.0
 RUN uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --no-deps sentence-transformers
 RUN uv pip install --no-cache 'llama-stack-api@git+https://github.com/opendatahub-io/llama-stack.git@v0.7.1+rhaiv.1#subdirectory=src/llama_stack_api'

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -22,8 +22,6 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | inference | remote::vllm | No | ❌ | Set the `VLLM_EMBEDDING_URL` environment variable |
 | inference | remote::watsonx | No | ❌ | Set the `WATSONX_API_KEY` environment variable |
 | responses | inline::builtin | No | ✅ | N/A |
-| safety | remote::passthrough | No | ❌ | Set the `PASSTHROUGH_SAFETY_URL` environment variable |
-| safety | remote::trustyai_fms | Yes (version 0.4.0) | ✅ | N/A |
 | tool_runtime | inline::file-search | No | ✅ | N/A |
 | tool_runtime | remote::brave-search | No | ✅ | N/A |
 | tool_runtime | remote::model-context-protocol | No | ✅ | N/A |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -4,7 +4,6 @@ apis:
 - responses
 - batches
 - inference
-- safety
 - tool_runtime
 - vector_io
 - files
@@ -111,28 +110,6 @@ providers:
       persistence:
         backend: kv_default
         namespace: vector_io::qdrant_remote
-  safety:
-    - provider_id: trustyai_fms
-      provider_type: remote::trustyai_fms
-      module: llama_stack_provider_trustyai_fms==0.4.0
-      config:
-        orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
-        ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
-        shields: {}
-    - provider_id: ${env.PASSTHROUGH_SAFETY_URL:+passthrough}
-      provider_type: remote::passthrough
-      config:
-        base_url: ${env.PASSTHROUGH_SAFETY_URL:=}
-        api_key: ${env.PASSTHROUGH_SAFETY_API_KEY:=}
-        # forward_headers maps keys from X-LlamaStack-Provider-Data to outbound
-        # HTTP headers sent to the downstream service. use this when callers pass
-        # per-request credentials (e.g. a tenant API token) rather than a shared
-        # static key. omit api_key above if you rely solely on forwarded headers.
-        #
-        # forward_headers:
-        #   maas_api_token: Authorization   # X-LlamaStack-Provider-Data key → header
-        #   tenant_id: X-Tenant-Id
-        #   team_id: X-Team-Id
   responses:
   - provider_id: meta-reference
     provider_type: inline::builtin
@@ -235,7 +212,6 @@ registered_resources:
     provider_id: ${env.EMBEDDING_PROVIDER:=vllm-embedding}
     provider_model_id: ${env.EMBEDDING_PROVIDER_MODEL_ID:=ibm-granite/granite-embedding-125m-english}
     model_type: embedding
-  shields: []
   vector_dbs: []
   tool_groups:
   - toolgroup_id: builtin::websearch

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -11,7 +11,6 @@ apis:
 - responses
 - batches
 - inference
-- safety
 - tool_runtime
 - vector_io
 - files
@@ -101,28 +100,6 @@ providers:
       persistence:
         backend: kv_default
         namespace: vector_io::qdrant_remote
-  safety:
-  - provider_id: trustyai_fms
-    provider_type: remote::trustyai_fms
-    module: llama_stack_provider_trustyai_fms==0.4.0
-    config:
-      orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
-      ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
-      shields: {}
-  - provider_id: ${env.PASSTHROUGH_SAFETY_URL:+passthrough}
-    provider_type: remote::passthrough
-    config:
-      base_url: ${env.PASSTHROUGH_SAFETY_URL:=}
-      api_key: ${env.PASSTHROUGH_SAFETY_API_KEY:=}
-        # forward_headers maps keys from X-LlamaStack-Provider-Data to outbound
-        # HTTP headers sent to the downstream service. use this when callers pass
-        # per-request credentials (e.g. a tenant API token) rather than a shared
-        # static key. omit api_key above if you rely solely on forwarded headers.
-        #
-        # forward_headers:
-        #   maas_api_token: Authorization   # X-LlamaStack-Provider-Data key → header
-        #   tenant_id: X-Tenant-Id
-        #   team_id: X-Team-Id
   responses:
   - provider_id: meta-reference
     provider_type: inline::builtin
@@ -225,7 +202,6 @@ registered_resources:
     provider_id: ${env.EMBEDDING_PROVIDER:=vllm-embedding}
     provider_model_id: ${env.EMBEDDING_PROVIDER_MODEL_ID:=ibm-granite/granite-embedding-125m-english}
     model_type: embedding
-  shields: []
   vector_dbs: []
   tool_groups:
   - toolgroup_id: builtin::websearch


### PR DESCRIPTION
# What does this PR do?
<!-- Provide a short summary of what this PR does and why. Link to relevant issues if applicable. -->
Taking out the Safety / Shields references, now deprecated by NVIDIA NeMo Guardrails and Guardrails Orchestrator.

<!-- If resolving an issue, uncomment and update the line below -->
<!-- Closes #[issue-number] -->
Closes RHAIENG-4304.
part of `RHAISTRAT-1362` / `RHAIENG-4271`

## Test Plan
<!-- Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.* -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed the `safety` API and all associated safety providers from the distribution.
  * Updated documentation to reflect the removal of safety API entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->