### PR TITLE
fix: skip GCP auth when workload identity provider secret is empty

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -170,7 +170,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud (Vertex)
-        if: matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
+        if: matrix.arch == 'amd64' && env.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ env.VERTEX_AI_PROJECT }}


### PR DESCRIPTION
## Summary
- Add `env.GCP_WORKLOAD_IDENTITY_PROVIDER != ''` guard to the Google Cloud auth step in `redhat-distro-container.yml`
- When the secret is not configured (empty/removed), the auth step is now skipped gracefully instead of crashing
- Downstream test scripts (`smoke.sh`, `run_integration_tests.sh`) already handle missing GCP credentials — they check for `GOOGLE_APPLICATION_CREDENTIALS` before adding Vertex AI models

Fixes #364

## Test plan
- [x] Verify CI passes on this PR (the auth step should be skipped, Vertex AI tests should be excluded)
- [ ] Confirm other PRs are no longer blocked

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline authentication conditions to enforce stricter credential validation and refine workflow execution logic for improved security in the automated build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->