### PR TITLE
fix: manually define mem requests in setup-vllm action

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -8,10 +8,10 @@ runs:
       run: |
         # Set VLLM_ARGS based on VLLM_MODE
         if [[ "$VLLM_MODE" == "inference" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /root/.cache/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192"
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /root/.cache/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192 --gpu-memory-utilization 0.50"
           VLLM_PORT=8000
         elif [[ "$VLLM_MODE" == "embedding" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /root/.cache/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /root/.cache/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english --gpu-memory-utilization 0.25"
           VLLM_PORT=8001
         else
           echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -49,11 +49,13 @@ pull_request_rules:
                   - files~=^\.github/workflows/redhat-distro-container\.yml$
                   - files~=^distribution/
                   - files~=^tests/
+                  - files~=^vllm/
           - and:
               - -files~=^\.github/actions/setup-vllm/action\.yml$
               - -files~=^\.github/workflows/redhat-distro-container\.yml$
               - -files~=^distribution/
               - -files~=^tests/
+              - -files~=^vllm/
 
     actions:
       merge:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Data Hub OGX Distribution
 
-[![Build](https://github.com/opendatahub-io/llama-stack-distribution/actions/workflows/redhat-distro-container.yml/badge.svg?branch=main)](https://github.com/opendatahub-io/llama-stack-distribution/actions/workflows/redhat-distro-container.yml)
+[![Build](https://github.com/opendatahub-io/ogx-distribution/actions/workflows/redhat-distro-container.yml/badge.svg?branch=main)](https://github.com/opendatahub-io/ogx-distribution/actions/workflows/redhat-distro-container.yml)
 
 This directory contains the necessary files to build an Open Data Hub-compatible container image for [OGX](https://github.com/ogx-ai/ogx).
 

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -1,5 +1,7 @@
 # vLLM CPU Container Images
 
+[![Build](https://github.com/opendatahub-io/ogx-distribution/actions/workflows/vllm-cpu-container.yml/badge.svg?branch=main)](https://github.com/opendatahub-io/ogx-distribution/actions/workflows/vllm-cpu-container.yml)
+
 This directory contains a Containerfile based on the official [vllm/vllm-openai-cpu](https://hub.docker.com/r/vllm/vllm-openai-cpu) image with pre-downloaded HuggingFace models baked in at build time.
 
 ## Build Arguments


### PR DESCRIPTION
# What does this PR do?
vllm 0.20.2 seems to require more manual memory management from us than 0.19 did - setting these values explicitly to allow both containers to run on the runner

also fix the mergify config, which merged the previous PR (https://github.com/opendatahub-io/ogx-distribution/pull/371) to bump without checking the CI action that caught this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated vLLM configuration to enhance inference operations with improved tool choice capabilities and optimized GPU memory management settings.
  * Fine-tuned embedding mode GPU memory allocation for better resource efficiency.
  * Refined CI/CD auto-merge rules and updated project documentation with current build status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->