### PR TITLE
fix: pin milvus-lite to 2.5.1 to avoid gRPC crash

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -100,6 +100,7 @@ PINNED_DEPENDENCIES = [
     "'ibm-cos-sdk-core==2.14.2'",
     "'ibm-cos-sdk==2.14.2'",
     "'setuptools==80.10.2'",
+    "'milvus-lite==2.5.1'",
 ]
 
 source_install_command_pypi_client = """uv pip install --no-cache 'ogx-api@git+https://github.com/opendatahub-io/ogx.git@{ogx_version}#subdirectory=src/ogx_api'

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -15,7 +15,8 @@ uv pip install --upgrade \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2' \
-    'setuptools==80.10.2'
+    'setuptools==80.10.2' \
+    'milvus-lite==2.5.1'
 uv pip install \
     'fonttools>=4.60.2' \
     'google-genai>=1.69.0' \


### PR DESCRIPTION
## Summary

- Pin `milvus-lite==2.5.1` in `PINNED_DEPENDENCIES` to prevent milvus-lite 3.x from being installed, which causes gRPC initialization crashes with `pymilvus==2.6.9`
- Regenerate `install-deps.sh` with the new pin

> **Note:** This pin may also need to be applied upstream in [opendatahub-io/ogx](https://github.com/opendatahub-io/ogx), but this change is needed now to unblock RHOAI teams that depend on OGX.

[RHOAIENG-62563](https://redhat.atlassian.net/browse/RHOAIENG-62563)

## Test plan

- [x] Built and pushed image with the pin to [quay.io/rh-ee-ngagan/llama-stack](https://quay.io/repository/rh-ee-ngagan/llama-stack?tab=tags) (tag `v1.0.2-rhaiv.0`)
- [x] Validated the image in Gen AI Studio
- [x] Verify milvus-lite 2.5.1 is installed in the container: `pip show milvus-lite`
- [x] Verify Milvus vector_io provider initializes without gRPC crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)