### PR TITLE
chore: remove ibm-cos-sdk

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -90,6 +90,7 @@ BASE_REQUIREMENTS = [
     f"ogx=={OGX_VERSION}",
 ]
 
+# TODO(efenness): It's likely that we don't need many of these dependencies - let's see what we can delete
 # Constrain packages we are patching to ensure reliable and repeatable build
 PINNED_DEPENDENCIES = [
     "'kfp-kubernetes==2.14.6'",
@@ -97,8 +98,6 @@ PINNED_DEPENDENCIES = [
     "'botocore==1.35.88'",
     "'boto3==1.35.88'",
     "'aiobotocore==2.16.1'",
-    "'ibm-cos-sdk-core==2.14.2'",
-    "'ibm-cos-sdk==2.14.2'",
     "'setuptools==80.10.2'",
     "'milvus-lite==2.5.1'",
 ]

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -13,8 +13,6 @@ uv pip install --upgrade \
     'botocore==1.35.88' \
     'boto3==1.35.88' \
     'aiobotocore==2.16.1' \
-    'ibm-cos-sdk-core==2.14.2' \
-    'ibm-cos-sdk==2.14.2' \
     'setuptools==80.10.2' \
     'milvus-lite==2.5.1'
 uv pip install \


### PR DESCRIPTION
This is not used in upstream OGX, and should not be included in the image.

It is likeley a pin to resolve dependency conflicts with the ragas external provider, which is no longer included in the distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed IBM Cloud Object Storage SDK from installation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->