### PR TITLE
chore: remove opentelemetry-instrumentation-botocore

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -408,7 +408,7 @@ def generate_install_deps_script(dependencies):
         "",
         dependencies.rstrip(),
         "",
-        "opentelemetry-bootstrap -a requirements | uv pip install --requirement -",
+        "opentelemetry-bootstrap -a requirements | grep -v opentelemetry-instrumentation-botocore | uv pip install --requirement -",
         "",
         "uv pip install tiktoken==0.12.0",
     ]

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -57,6 +57,6 @@ uv pip install \
 uv pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 uv pip install --no-deps sentence-transformers
 
-opentelemetry-bootstrap -a requirements | uv pip install --requirement -
+opentelemetry-bootstrap -a requirements | grep -v opentelemetry-instrumentation-botocore | uv pip install --requirement -
 
 uv pip install tiktoken==0.12.0


### PR DESCRIPTION
This package is not yet available in our index.

The impact of removing this is likely low - possibly missing some telemetry for providers that use AWS services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved dependency installation to properly exclude specific packages during setup, resulting in faster, cleaner installations with better system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->