### PR TITLE
chore: exclude milvus-lite on ppc64le

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -99,7 +99,7 @@ PINNED_DEPENDENCIES = [
     "'boto3==1.35.88'",
     "'aiobotocore==2.16.1'",
     "'setuptools==80.10.2'",
-    "'milvus-lite==2.5.1'",
+    "'milvus-lite==2.5.1; platform_machine != \"ppc64le\"'",
 ]
 
 source_install_command_pypi_client = """uv pip install --no-cache 'ogx-api@git+https://github.com/opendatahub-io/ogx.git@{ogx_version}#subdirectory=src/ogx_api'
@@ -325,12 +325,10 @@ def get_dependencies():
 
             # Pin pymilvus to 2.6.9 to avoid gRPC crash
             # 2.6.10 crashes Milvus Lite gRPC init with empty dns:/// target
+            # Use plain pymilvus (no [milvus-lite] extra) so the explicit
+            # milvus-lite pin in PINNED_DEPENDENCIES is the sole source
             packages = [
-                "'pymilvus[milvus-lite]==2.6.9'"
-                if "pymilvus[milvus-lite]" in package
-                else "'pymilvus==2.6.9'"
-                if "pymilvus" in package
-                else package
+                "'pymilvus==2.6.9'" if "pymilvus" in package else package
                 for package in packages
             ]
 

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -14,14 +14,13 @@ uv pip install --upgrade \
     'boto3==1.35.88' \
     'aiobotocore==2.16.1' \
     'setuptools==80.10.2' \
-    'milvus-lite==2.5.1'
+    'milvus-lite==2.5.1; platform_machine != "ppc64le"'
 uv pip install \
     'fonttools>=4.60.2' \
     'google-genai>=1.69.0' \
     'mcp>=1.23.0' \
     'nltk>=3.9.4' \
     'pymilvus==2.6.9' \
-    'pymilvus[milvus-lite]==2.6.9' \
     'pypdf>=6.10.0' \
     aiosqlite \
     asyncpg \


### PR DESCRIPTION
## Summary
- Exclude `milvus-lite` on ppc64le using a PEP 508 `platform_machine` marker, as milvus-lite is not supported on that architecture
- Remove the `pymilvus[milvus-lite]` extra so the explicit pin in `PINNED_DEPENDENCIES` is the sole source of `milvus-lite`, preventing version conflicts

## Test plan
- [ ] Verify ppc64le build no longer attempts to install milvus-lite
- [ ] Verify x86_64/arm64 builds still install milvus-lite==2.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved platform-specific dependency handling by conditionally installing `milvus-lite` only on supported platforms, excluding `ppc64le` architecture
  * Standardized dependency pinning to ensure consistent and reliable builds across different system configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->