### PR TITLE
fix: update entrypoint to remove "stack" subcommand

### DIFF
--- a/distribution/entrypoint.sh
+++ b/distribution/entrypoint.sh
@@ -18,7 +18,7 @@ if [ -n "$OTEL_SERVICE_NAME" ]; then
     --metrics_exporter=otlp \
     --service_name="$OTEL_SERVICE_NAME" \
     -- \
-    ogx stack run "$CONFIG" "$@"
+    ogx run "$CONFIG" "$@"
 fi
 
-exec ogx stack run "$CONFIG" "$@"
+exec ogx run "$CONFIG" "$@"

--- a/docs/google-walkthrough.md
+++ b/docs/google-walkthrough.md
@@ -65,7 +65,7 @@ ogx stack list-deps starter | xargs -L1 uv pip install
 # Choose "aaet-dev" if you are on the core OGX team.
 export VERTEX_AI_PROJECT=aaet-dev
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud/application_default_credentials.json
-ogx stack run starter
+ogx run starter
 ```
 
 ## Vertex OpenAI API examples with OGX


### PR DESCRIPTION
When running the distribution, we can see this message:
```
/opt/app-root/lib64/python3.12/site-packages/ogx/cli/stack/run.py:234: FutureWarning: 
'ogx stack run' is deprecated and will be removed in a future release. Use 'ogx run' instead.
```

This is because since https://github.com/ogx-ai/ogx/pull/5689 the command should be `ogx run ...`

This PR updates the entrypoint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated distribution startup process to use the `ogx run` command.

* **Documentation**
  * Updated walkthrough documentation to reflect current command usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->