### PR TITLE
fix: enable file_processors API with inline::pypdf for RAG

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -11,6 +11,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | API | Provider | External? | Enabled by default? | How to enable |
 |-----|----------|-----------|---------------------|---------------|
 | batches | inline::reference | No | ✅ | N/A |
+| file_processors | inline::pypdf | No | ✅ | N/A |
 | files | inline::localfs | No | ✅ | N/A |
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | Dependency only* | Requires a custom `config.yaml` |

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -317,9 +317,12 @@ def get_dependencies():
             # Sort and deduplicate packages
             packages = sorted(set(packages))
 
-            # Add quotes to packages with > or < to prevent bash redirection
+            # Add quotes to packages with >, <, or [ to prevent bash
+            # redirection and glob interpretation (shellcheck SC2102).
             packages = [
-                f"'{package}'" if (">" in package or "<" in package) else package
+                f"'{package}'"
+                if (">" in package or "<" in package or "[" in package)
+                else package
                 for package in packages
             ]
 

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -7,6 +7,7 @@ apis:
 - tool_runtime
 - vector_io
 - files
+- file_processors
 providers:
   inference:
   - provider_id: ${env.VLLM_URL:+vllm-inference}
@@ -165,6 +166,10 @@ providers:
       metadata_store:
         backend: sql_default
         table_name: files_metadata
+  file_processors:
+  - provider_id: pypdf
+    provider_type: inline::pypdf
+    config: {}
   batches:
   - provider_id: reference
     provider_type: inline::reference

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -14,6 +14,7 @@ apis:
 - tool_runtime
 - vector_io
 - files
+- file_processors
 providers:
   inference:
   - provider_id: ${env.VLLM_URL:+vllm-inference}
@@ -155,6 +156,10 @@ providers:
       metadata_store:
         backend: sql_default
         table_name: files_metadata
+  file_processors:
+  - provider_id: pypdf
+    provider_type: inline::pypdf
+    config: {}
   batches:
   - provider_id: reference
     provider_type: inline::reference

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -22,6 +22,8 @@ uv pip install \
     'nltk>=3.9.4' \
     'pymilvus==2.6.9' \
     'pypdf>=6.10.0' \
+    'pypdf>=6.7.2' \
+    'sqlalchemy[asyncio]' \
     aiosqlite \
     asyncpg \
     boto3 \
@@ -46,7 +48,6 @@ uv pip install \
     scikit-learn \
     scipy \
     sentencepiece \
-    sqlalchemy[asyncio] \
     tokenizers \
     tqdm \
     transformers \

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,0 +1,48 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<<
+/Length 63
+>>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(OGX-RAG-SMOKE-7f3a9c2e8b1d4f06) Tj
+ET
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000010 00000 n
+0000000060 00000 n
+0000000120 00000 n
+0000000210 00000 n
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+295
+%%EOF

--- a/tests/fixtures/sample.pdf
+++ b/tests/fixtures/sample.pdf
@@ -1,48 +1,68 @@
-%PDF-1.4
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/Type /Catalog
-/Pages 2 0 R
+/F1 2 0 R
 >>
 endobj
 2 0 obj
 <<
-/Type /Pages
-/Kids [3 0 R]
-/Count 1
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
 >>
 endobj
 3 0 obj
 <<
-/Type /Page
-/Parent 2 0 R
-/MediaBox [0 0 612 792]
-/Contents 4 0 R
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 4 0 obj
 <<
-/Length 63
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260518113442+01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20260518113442+01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 254
 >>
 stream
-BT
-/F1 12 Tf
-100 700 Td
-(OGX-RAG-SMOKE-7f3a9c2e8b1d4f06) Tj
-ET
+Gas3,_+qj4'SYL/:N;[m;Oj^\$go^&`[E9u]3n-`nP2,34(dVaG^L0E@:Ebg(B<AU)@?iJHYj9U'(2&(3X7\/@T%__Yb9C/Y()6W8#6oua%b<);>VWdmn_r\J5%*q%,rP2K0Alia=ZTr2#`DtdgNH:n\FYqD6qJnk=rBf[Ejc4Eqa0XF.Vgm>N&QW5>tl*l?pI[?K.0DGFfJD1BQeXc6%?+&VK206;3cMT4#nD5"d_5+FKKsY60`t!4fX;!!~>endstream
 endobj
 xref
-0 5
-0000000000 65535 f
-0000000010 00000 n
-0000000060 00000 n
-0000000120 00000 n
-0000000210 00000 n
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
 trailer
 <<
-/Size 5
-/Root 1 0 R
+/ID 
+[<e26d63af9f67dacc2117183202275d30><e26d63af9f67dacc2117183202275d30>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
 >>
 startxref
-295
+1171
 %%EOF

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -174,6 +174,36 @@ function test_postgres_populated {
   return 0
 }
 
+function test_file_processor_pypdf {
+  echo "===> Verifying file processor (inline::pypdf) with sample PDF..."
+
+  # Must match text embedded in tests/fixtures/sample.pdf (not guessable by an LLM).
+  local expected_marker="OGX-RAG-SMOKE-7f3a9c2e8b1d4f06"
+  local pdf_path="$SCRIPT_DIR/fixtures/sample.pdf"
+  if [ ! -f "$pdf_path" ]; then
+    echo "===> Sample PDF not found at $pdf_path :("
+    return 1
+  fi
+
+  resp=$(curl -fsS "$OGX_BASE_URL/v1alpha/file-processors/process" -F "file=@$pdf_path;type=application/pdf")
+  echo "Response: $resp"
+
+  if ! echo "$resp" | grep -q '"processor"[[:space:]]*:[[:space:]]*"pypdf"'; then
+    echo "===> File processor response missing pypdf metadata :("
+    docker logs ogx 2>/dev/null | tail -50 || true
+    return 1
+  fi
+
+  if ! echo "$resp" | grep -qF "$expected_marker"; then
+    echo "===> File processor did not extract expected PDF marker ($expected_marker) :("
+    docker logs ogx 2>/dev/null | tail -50 || true
+    return 1
+  fi
+
+  echo "===> File processor (inline::pypdf) is working :)"
+  return 0
+}
+
 main() {
   echo "===> Starting smoke test..."
   start_and_wait_for_ogx_container
@@ -232,6 +262,10 @@ main() {
     if ! test_postgres_populated; then
       failed_checks+=("postgres:data")
     fi
+  fi
+
+  if ! test_file_processor_pypdf; then
+    failed_checks+=("file_processor:pypdf")
   fi
 
   # Report results


### PR DESCRIPTION
## Summary

- Enable the `file_processors` API with `inline::pypdf` only (not `inline::auto`), so PDF ingestion works for vector-store RAG without pulling in `markitdown[all]`.
- Regenerate `install-deps.sh` via the distribution build hook (adds `pypdf` provider dep; quotes `sqlalchemy[asyncio]`).
- Add a smoke test that uploads `tests/fixtures/sample.pdf` and asserts extraction of a non-guessable marker string.

Relates to [RHAIENG-5114](https://redhat.atlassian.net/browse/RHAIENG-5114).

Replaces the reverted approach in #376, which used `inline::auto` and added heavy optional dependencies.

## Test plan

- [ ] CI passes (build, pre-commit, smoke tests)
- [ ] Smoke test `test_file_processor_pypdf` passes against a built image
- [ ] `POST /v1alpha/file-processors/process` with a PDF returns `metadata.processor: pypdf` and extracted chunk content


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File processors API with PDF processing capability powered by an inline pypdf provider.

* **Tests**
  * Added smoke test to verify file processor endpoint functionality and PDF processing capabilities.

* **Chores**
  * Updated dependencies and build configuration to support the new file processors API.
  * Enhanced dependency specification handling in installation scripts.
  * Updated API documentation and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->