### PR TITLE
fix: add `file_processors` API

### DIFF
--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -7,6 +7,7 @@ apis:
 - tool_runtime
 - vector_io
 - files
+- file_processors
 providers:
   inference:
   - provider_id: ${env.VLLM_URL:+vllm-inference}
@@ -165,6 +166,16 @@ providers:
       metadata_store:
         backend: sql_default
         table_name: files_metadata
+  file_processors:
+  - provider_id: pypdf
+    provider_type: inline::pypdf
+    config: {}
+  - provider_id: docling
+    provider_type: inline::docling
+    config: {}
+  - provider_id: docling-serve
+    provider_type: remote::docling-serve
+    config: {}
   batches:
   - provider_id: reference
     provider_type: inline::reference

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -14,6 +14,7 @@ apis:
 - tool_runtime
 - vector_io
 - files
+- file_processors
 providers:
   inference:
   - provider_id: ${env.VLLM_URL:+vllm-inference}
@@ -155,6 +156,16 @@ providers:
       metadata_store:
         backend: sql_default
         table_name: files_metadata
+  file_processors:
+  - provider_id: pypdf
+    provider_type: inline::pypdf
+    config: {}
+  - provider_id: docling
+    provider_type: inline::docling
+    config: {}
+  - provider_id: docling-serve
+    provider_type: remote::docling-serve
+    config: {}
   batches:
   - provider_id: reference
     provider_type: inline::reference

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -22,10 +22,12 @@ uv pip install \
     'nltk>=3.9.4' \
     'pymilvus==2.6.9' \
     'pypdf>=6.10.0' \
+    'pypdf>=6.7.2' \
     aiosqlite \
     asyncpg \
     boto3 \
     chardet \
+    docling \
     einops \
     faiss-cpu \
     fastapi \


### PR DESCRIPTION
...including `inline::pypdf`, `inline::docling`, and `remote::docling-serve` providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced the file_processors API with three processing backends: pypdf and docling as inline processors, and docling-serve as a remote service provider
  * Users can now leverage multiple file processing methods to handle various document formats

* **Chores**
  * Updated pypdf dependency version requirement
  * Added docling as a new dependency to support file processing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->