### PR TITLE
fix: deduplicate pypdf deps and add RAG e2e smoke test

### DIFF
--- a/distribution/build.py
+++ b/distribution/build.py
@@ -314,8 +314,22 @@ def get_dependencies():
                     packages.append(parts_list[i])
                     i += 1
 
-            # Sort and deduplicate packages
-            packages = sorted(set(packages))
+            # Deduplicate packages by name, keeping the highest version spec
+            seen: dict[str, str] = {}
+            for pkg in packages:
+                name = re.split(r"[><=!~\[]", pkg)[0].lower().replace("-", "_")
+                if name not in seen:
+                    seen[name] = pkg
+                else:
+                    from packaging.version import Version
+
+                    def _extract_ver(s):
+                        m = re.search(r"(\d+(?:\.\d+)*)", s)
+                        return Version(m.group(1)) if m else Version("0")
+
+                    if _extract_ver(pkg) > _extract_ver(seen[name]):
+                        seen[name] = pkg
+            packages = sorted(seen.values())
 
             # Add quotes to packages with >, <, or [ to prevent bash
             # redirection and glob interpretation (shellcheck SC2102).

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -22,7 +22,6 @@ uv pip install \
     'nltk>=3.9.4' \
     'pymilvus==2.6.9' \
     'pypdf>=6.10.0' \
-    'pypdf>=6.7.2' \
     'sqlalchemy[asyncio]' \
     aiosqlite \
     asyncpg \

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -204,6 +204,74 @@ function test_file_processor_pypdf {
   return 0
 }
 
+function test_rag_file_ingestion {
+  echo "===> Verifying RAG file ingestion pipeline (upload → vector store → index)..."
+
+  local pdf_path="$SCRIPT_DIR/fixtures/sample.pdf"
+  if [ ! -f "$pdf_path" ]; then
+    echo "===> Sample PDF not found at $pdf_path :("
+    return 1
+  fi
+
+  # 1. Upload file
+  upload_resp=$(curl -fsS "$OGX_BASE_URL/v1/files" \
+    -F "file=@$pdf_path;type=application/pdf" \
+    -F "purpose=assistants")
+  echo "Upload response: $upload_resp"
+
+  file_id=$(echo "$upload_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+  if [ -z "$file_id" ]; then
+    echo "===> Failed to upload file :("
+    docker logs ogx 2>/dev/null | tail -50 || true
+    return 1
+  fi
+  echo "===> Uploaded file: $file_id"
+
+  # 2. Create vector store
+  vs_resp=$(curl -fsS "$OGX_BASE_URL/v1/vector_stores" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"smoke-test-rag"}')
+  echo "Vector store response: $vs_resp"
+
+  vs_id=$(echo "$vs_resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)
+  if [ -z "$vs_id" ]; then
+    echo "===> Failed to create vector store :("
+    docker logs ogx 2>/dev/null | tail -50 || true
+    return 1
+  fi
+  echo "===> Created vector store: $vs_id"
+
+  # 3. Attach file to vector store
+  attach_resp=$(curl -fsS "$OGX_BASE_URL/v1/vector_stores/$vs_id/files" \
+    -H "Content-Type: application/json" \
+    -d "{\"file_id\":\"$file_id\"}")
+  echo "Attach response: $attach_resp"
+
+  # 4. Poll until file status is completed or failed (max 30s)
+  echo "===> Polling file ingestion status..."
+  for i in {1..30}; do
+    status_resp=$(curl -fsS "$OGX_BASE_URL/v1/vector_stores/$vs_id/files/$file_id" 2>/dev/null || echo '{}')
+    file_status=$(echo "$status_resp" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null)
+
+    if [ "$file_status" = "completed" ]; then
+      echo "===> File ingestion completed successfully :)"
+      return 0
+    elif [ "$file_status" = "failed" ]; then
+      echo "===> File ingestion failed :("
+      echo "Status response: $status_resp"
+      docker logs ogx 2>/dev/null | tail -50 || true
+      return 1
+    fi
+
+    echo "  Attempt $i: status=$file_status, waiting..."
+    sleep 1
+  done
+
+  echo "===> File ingestion timed out after 30s :("
+  docker logs ogx 2>/dev/null | tail -50 || true
+  return 1
+}
+
 main() {
   echo "===> Starting smoke test..."
   start_and_wait_for_ogx_container
@@ -266,6 +334,10 @@ main() {
 
   if ! test_file_processor_pypdf; then
     failed_checks+=("file_processor:pypdf")
+  fi
+
+  if ! test_rag_file_ingestion; then
+    failed_checks+=("rag:file_ingestion")
   fi
 
   # Report results


### PR DESCRIPTION
## Summary

- **Fix pypdf duplication in `install-deps.sh`**: The build script's `set()`-based dedup treated `pypdf>=6.10.0` and `pypdf>=6.7.2` as distinct strings. Replaced with name-aware dedup that normalizes package names and keeps the highest version specifier using `packaging.version.Version`.
- **Add RAG file ingestion e2e smoke test**: Exercises the full pipeline — upload file → create vector store → attach file → poll until indexed. This would have caught the `file_processors` regression (RHAIENG-5114) caused by upstream ogx-ai/ogx#5339.

Follow-up to #386.

## Test plan

- [ ] CI passes (build, pre-commit, smoke tests)
- [ ] `install-deps.sh` contains a single `pypdf` entry after regeneration
- [ ] `test_rag_file_ingestion` passes against a built image with Postgres + pgvector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency resolution to deduplicate packages and retain the highest version constraint.
  * Updated pypdf dependency to version >=6.10.0 for improved PDF handling.

* **Tests**
  * Added a smoke test for the RAG file ingestion workflow with vector store integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->