### PR TITLE
fix: vllm build should fail if model download fails

### DIFF
--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -22,6 +22,7 @@ RUN if [ -z "${INFERENCE_MODEL}" ]; then \
     fi
 
 RUN --mount=type=secret,id=hf_token \
+    set -e && \
     for model in "${INFERENCE_MODEL}" "${EMBEDDING_MODEL}"; do \
         model_path="${MODEL_CACHE_DIR}/${model}" && \
         mkdir -p "${model_path}" && \


### PR DESCRIPTION
e.g. this job should not have passed https://github.com/opendatahub-io/ogx-distribution/actions/runs/26103187952/job/76759646524
