### PR TITLE
chore: upgrade vllm base image to 0.21.0

### DIFF
--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -2,7 +2,7 @@
 #
 # Reference: https://hub.docker.com/r/vllm/vllm-openai-cpu
 
-FROM vllm/vllm-openai-cpu:v0.20.2
+FROM vllm/vllm-openai-cpu:v0.21.0
 
 RUN pip install "huggingface-hub[cli]"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated vLLM OpenAI-compatible base image from v0.20.2 to v0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->