### PR TITLE
feat: migrate MaaS tests to LiteLLM service

### DIFF
--- a/.github/workflows/responses-vllm-maas.yml
+++ b/.github/workflows/responses-vllm-maas.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   PROVIDER_NAME: vllm-maas
-  EMBEDDING_MODEL: vllm-embedding/nomic-embed-text-v1-5
+  EMBEDDING_MODEL: vllm-embedding/Nomic-embed-text-v2-moe
   IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
   IMAGE_TAG: source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c
 
@@ -48,7 +48,7 @@ jobs:
       - name: Resolve models
         id: models
         run: |
-          default='["vllm-inference/llama-3-2-3b"]'
+          default='["vllm-inference/Qwen3.6-35B-A3B"]'
           input='${{ inputs.models }}'
           if [ -z "$input" ]; then
             echo "json=$default" >> "$GITHUB_OUTPUT"
@@ -92,9 +92,9 @@ jobs:
             VLLM_EMBEDDING_URL=${{ secrets.MAAS_EMBEDDING_URL }}
             VLLM_EMBEDDING_API_TOKEN=${{ secrets.MAAS_EMBEDDING_API_TOKEN }}
             TAVILY_SEARCH_API_KEY=${{ secrets.TAVILY_SEARCH_API_KEY }}
-            EMBEDDING_MODEL=vllm-embedding/nomic-embed-text-v1-5
+            EMBEDDING_MODEL=vllm-embedding/Nomic-embed-text-v2-moe
             EMBEDDING_PROVIDER=vllm-embedding
-            EMBEDDING_PROVIDER_MODEL_ID=nomic-embed-text-v1-5
+            EMBEDDING_PROVIDER_MODEL_ID=Nomic-embed-text-v2-moe
 
       - name: Clone upstream tests
         shell: bash


### PR DESCRIPTION
## Summary

Migrate vLLM MaaS test workflow to use the new LiteLLM-based MaaS service with updated models.

- **Default text model**: `vllm-inference/llama-3-2-3b` → `vllm-inference/Qwen3.6-35B-A3B`
- **Embedding model**: `vllm-embedding/nomic-embed-text-v1-5` → `vllm-embedding/Nomic-embed-text-v2-moe`

### Required: Update GitHub Secrets

The following secrets need to be updated in repo settings to point to the new LiteLLM endpoint:

| Secret | New value |
|--------|-----------|
| `MAAS_VLLM_URL` | `https://litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com/v1` |
| `MAAS_VLLM_API_TOKEN` | *(new API key)* |
| `MAAS_EMBEDDING_URL` | `https://litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com/v1` |
| `MAAS_EMBEDDING_API_TOKEN` | *(same API key)* |

### Available models on new service

| Model ID | Type |
|----------|------|
| `Qwen3.6-35B-A3B` | Text (default) |
| `Granite-Vision-3.2` | Vision |
| `Qwen2.5-VL-7B-Instruct` | Vision |
| `Nomic-embed-text-v2-moe` | Embedding |

## Test plan

- [ ] Update GitHub secrets to new LiteLLM endpoint
- [ ] Run: `gh workflow run "Responses: vLLM MaaS" --ref migrate-maas-litellm`
- [ ] Verify tests pass with Qwen3.6-35B-A3B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vLLM MaaS test workflow to use a newer embedding model and a new default inference model for empty model inputs.
  * Adjusted test server configuration and environment variables to align with the updated embedding model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->