### PR TITLE
fix: address review feedback and parallelize model tests

### DIFF
--- a/.github/workflows/responses-openai.yml
+++ b/.github/workflows/responses-openai.yml
@@ -46,13 +46,14 @@ jobs:
           fi
       - name: Resolve models
         id: models
+        env:
+          INPUT_MODELS: ${{ inputs.models || vars.TEST_MODELS_OPENAI }}
         run: |
           default='["openai/gpt-4.1-nano"]'
-          input='${{ inputs.models }}'
-          if [ -z "$input" ]; then
+          if [ -z "$INPUT_MODELS" ]; then
             echo "json=$default" >> "$GITHUB_OUTPUT"
           else
-            echo "json=$(echo "$input" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
+            echo "json=$(printf '%s' "$INPUT_MODELS" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -64,7 +65,6 @@ jobs:
       matrix:
         model: ${{ fromJson(needs.check.outputs.models_json) }}
     permissions:
-      id-token: write
       contents: read
       checks: write
     steps:
@@ -95,8 +95,10 @@ jobs:
       - name: Clone upstream tests
         shell: bash
         run: |
-          git clone --branch v1.0.0 --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
+          git clone --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
           cd /tmp/ogx-tests
+          git fetch --depth 1 origin 9769a91c543e527389707e8a342339528d23c9f5 # v1.0.0
+          git checkout 9769a91c543e527389707e8a342339528d23c9f5
 
           uv venv --clear
           source .venv/bin/activate
@@ -104,20 +106,22 @@ jobs:
 
       - name: Derive short model name
         id: model
+        env:
+          FULL_MODEL: ${{ matrix.model }}
         run: |
-          full='${{ matrix.model }}'
-          echo "short=${full##*/}" >> "$GITHUB_OUTPUT"
+          echo "short=${FULL_MODEL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Run responses tests
         shell: bash
+        env:
+          MODEL: ${{ matrix.model }}
+          SHORT: ${{ steps.model.outputs.short }}
         run: |
           cd /tmp/ogx-tests
           source .venv/bin/activate
           mkdir -p /tmp/test-results
 
           SKIP_TESTS="test_response_connector_resolution_mcp_tool"
-          MODEL='${{ matrix.model }}'
-          SHORT='${{ steps.model.outputs.short }}'
 
           python -m pytest -s -v tests/integration/responses/ \
             -k "not ($SKIP_TESTS)" \
@@ -128,18 +132,9 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Check for test results
-        id: results
-        if: always()
-        run: |
-          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Publish test report
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -148,7 +143,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}
@@ -156,7 +151,7 @@ jobs:
           retention-days: 90
 
       - name: Cleanup
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           for c in ogx postgres; do
             docker rm -f "$c" 2>/dev/null || true

--- a/.github/workflows/responses-openai.yml
+++ b/.github/workflows/responses-openai.yml
@@ -24,7 +24,7 @@ env:
   PROVIDER_NAME: openai
   EMBEDDING_MODEL: openai/text-embedding-3-small
   IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
-  IMAGE_TAG: source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c
+  IMAGE_TAG: ${{ inputs.image_tag || 'source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c' }}
 
 jobs:
   check:
@@ -128,8 +128,18 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Publish test report
+      - name: Check for test results
+        id: results
         if: always()
+        run: |
+          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish test report
+        if: always() && steps.results.outputs.found == 'true'
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -138,7 +148,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.results.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}

--- a/.github/workflows/responses-vertexai.yml
+++ b/.github/workflows/responses-vertexai.yml
@@ -47,13 +47,14 @@ jobs:
           fi
       - name: Resolve models
         id: models
+        env:
+          INPUT_MODELS: ${{ inputs.models || vars.TEST_MODELS_VERTEXAI }}
         run: |
           default='["vertexai/publishers/google/models/gemini-2.0-flash"]'
-          input='${{ inputs.models }}'
-          if [ -z "$input" ]; then
+          if [ -z "$INPUT_MODELS" ]; then
             echo "json=$default" >> "$GITHUB_OUTPUT"
           else
-            echo "json=$(echo "$input" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
+            echo "json=$(printf '%s' "$INPUT_MODELS" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -110,8 +111,10 @@ jobs:
       - name: Clone upstream tests
         shell: bash
         run: |
-          git clone --branch v1.0.0 --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
+          git clone --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
           cd /tmp/ogx-tests
+          git fetch --depth 1 origin 9769a91c543e527389707e8a342339528d23c9f5 # v1.0.0
+          git checkout 9769a91c543e527389707e8a342339528d23c9f5
 
           uv venv --clear
           source .venv/bin/activate
@@ -119,20 +122,22 @@ jobs:
 
       - name: Derive short model name
         id: model
+        env:
+          FULL_MODEL: ${{ matrix.model }}
         run: |
-          full='${{ matrix.model }}'
-          echo "short=${full##*/}" >> "$GITHUB_OUTPUT"
+          echo "short=${FULL_MODEL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Run responses tests
         shell: bash
+        env:
+          MODEL: ${{ matrix.model }}
+          SHORT: ${{ steps.model.outputs.short }}
         run: |
           cd /tmp/ogx-tests
           source .venv/bin/activate
           mkdir -p /tmp/test-results
 
           SKIP_TESTS="test_response_connector_resolution_mcp_tool"
-          MODEL='${{ matrix.model }}'
-          SHORT='${{ steps.model.outputs.short }}'
 
           python -m pytest -s -v tests/integration/responses/ \
             -k "not ($SKIP_TESTS)" \
@@ -143,18 +148,9 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Check for test results
-        id: results
-        if: always()
-        run: |
-          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Publish test report
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -163,7 +159,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}
@@ -171,7 +167,7 @@ jobs:
           retention-days: 90
 
       - name: Cleanup
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           for c in ogx postgres; do
             docker rm -f "$c" 2>/dev/null || true

--- a/.github/workflows/responses-vertexai.yml
+++ b/.github/workflows/responses-vertexai.yml
@@ -24,7 +24,7 @@ env:
   PROVIDER_NAME: vertexai
   EMBEDDING_MODEL: vertexai/publishers/google/models/gemini-embedding-2
   IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
-  IMAGE_TAG: source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c
+  IMAGE_TAG: ${{ inputs.image_tag || 'source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c' }}
 
 jobs:
   check:
@@ -143,8 +143,18 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Publish test report
+      - name: Check for test results
+        id: results
         if: always()
+        run: |
+          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish test report
+        if: always() && steps.results.outputs.found == 'true'
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -153,7 +163,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.results.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}

--- a/.github/workflows/responses-vllm-maas.yml
+++ b/.github/workflows/responses-vllm-maas.yml
@@ -47,13 +47,14 @@ jobs:
           fi
       - name: Resolve models
         id: models
+        env:
+          INPUT_MODELS: ${{ inputs.models || vars.TEST_MODELS_VLLM_MAAS }}
         run: |
           default='["vllm-inference/Qwen3.6-35B-A3B"]'
-          input='${{ inputs.models }}'
-          if [ -z "$input" ]; then
+          if [ -z "$INPUT_MODELS" ]; then
             echo "json=$default" >> "$GITHUB_OUTPUT"
           else
-            echo "json=$(echo "$input" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
+            echo "json=$(printf '%s' "$INPUT_MODELS" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -65,7 +66,6 @@ jobs:
       matrix:
         model: ${{ fromJson(needs.check.outputs.models_json) }}
     permissions:
-      id-token: write
       contents: read
       checks: write
     steps:
@@ -99,8 +99,10 @@ jobs:
       - name: Clone upstream tests
         shell: bash
         run: |
-          git clone --branch v1.0.0 --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
+          git clone --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
           cd /tmp/ogx-tests
+          git fetch --depth 1 origin 9769a91c543e527389707e8a342339528d23c9f5 # v1.0.0
+          git checkout 9769a91c543e527389707e8a342339528d23c9f5
 
           uv venv --clear
           source .venv/bin/activate
@@ -108,20 +110,22 @@ jobs:
 
       - name: Derive short model name
         id: model
+        env:
+          FULL_MODEL: ${{ matrix.model }}
         run: |
-          full='${{ matrix.model }}'
-          echo "short=${full##*/}" >> "$GITHUB_OUTPUT"
+          echo "short=${FULL_MODEL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Run responses tests
         shell: bash
+        env:
+          MODEL: ${{ matrix.model }}
+          SHORT: ${{ steps.model.outputs.short }}
         run: |
           cd /tmp/ogx-tests
           source .venv/bin/activate
           mkdir -p /tmp/test-results
 
           SKIP_TESTS="test_response_connector_resolution_mcp_tool"
-          MODEL='${{ matrix.model }}'
-          SHORT='${{ steps.model.outputs.short }}'
 
           python -m pytest -s -v tests/integration/responses/ \
             -k "not ($SKIP_TESTS)" \
@@ -132,18 +136,9 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Check for test results
-        id: results
-        if: always()
-        run: |
-          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Publish test report
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -152,7 +147,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always() && steps.results.outputs.found == 'true'
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}
@@ -160,7 +155,7 @@ jobs:
           retention-days: 90
 
       - name: Cleanup
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           for c in ogx postgres; do
             docker rm -f "$c" 2>/dev/null || true

--- a/.github/workflows/responses-vllm-maas.yml
+++ b/.github/workflows/responses-vllm-maas.yml
@@ -24,7 +24,7 @@ env:
   PROVIDER_NAME: vllm-maas
   EMBEDDING_MODEL: vllm-embedding/Nomic-embed-text-v2-moe
   IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
-  IMAGE_TAG: source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c
+  IMAGE_TAG: ${{ inputs.image_tag || 'source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c' }}
 
 jobs:
   check:
@@ -132,8 +132,18 @@ jobs:
             --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
             || [ $? -eq 5 ]
 
-      - name: Publish test report
+      - name: Check for test results
+        id: results
         if: always()
+        run: |
+          if ls /tmp/test-results/*.xml 1>/dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish test report
+        if: always() && steps.results.outputs.found == 'true'
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
@@ -142,7 +152,7 @@ jobs:
           fail-on-error: 'false'
 
       - name: Upload artifacts
-        if: always()
+        if: always() && steps.results.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}

--- a/.github/workflows/responses-weekly.yml
+++ b/.github/workflows/responses-weekly.yml
@@ -65,7 +65,7 @@ jobs:
   report:
     name: Publish Test Report
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [test-openai, test-vertexai, test-vllm-maas]
 
     steps:
@@ -90,7 +90,7 @@ jobs:
           merge-multiple: true
 
       - name: Debug downloaded artifacts
-        if: always()
+        if: ${{ !cancelled() }}
         run: find junit-results -type f 2>/dev/null || echo "No junit-results directory found"
 
       - name: List downloaded results
@@ -124,7 +124,7 @@ jobs:
           cp scripts/report-template.html "${PUBLISH_DIR}/index.html"
 
       - name: Deploy to GitHub Pages
-        if: always()
+        if: ${{ !cancelled() }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
           keep_files: true
 
       - name: Print report URL
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           SUBFOLDER="${{ steps.deploy.outputs.subfolder }}"
           BASE="https://opendatahub-io.github.io/ogx-distribution"

--- a/.github/workflows/responses-weekly.yml
+++ b/.github/workflows/responses-weekly.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   # ── OpenAI ──────────────────────────────────────────────────────
   test-openai:
-    if: inputs.run_openai != false
+    if: github.event_name == 'schedule' || inputs.run_openai != false
     uses: ./.github/workflows/responses-openai.yml
     with:
       models: ${{ inputs.openai_models }}
@@ -47,7 +47,7 @@ jobs:
 
   # ── Vertex AI ───────────────────────────────────────────────────
   test-vertexai:
-    if: inputs.run_vertexai != false
+    if: github.event_name == 'schedule' || inputs.run_vertexai != false
     uses: ./.github/workflows/responses-vertexai.yml
     with:
       models: ${{ inputs.vertexai_models }}
@@ -55,7 +55,7 @@ jobs:
 
   # ── vLLM MaaS ──────────────────────────────────────────────────
   test-vllm-maas:
-    if: inputs.run_vllm_maas != false
+    if: github.event_name == 'schedule' || inputs.run_vllm_maas != false
     uses: ./.github/workflows/responses-vllm-maas.yml
     with:
       models: ${{ inputs.vllm_maas_models }}

--- a/README.md
+++ b/README.md
@@ -72,23 +72,24 @@ podman run \
 > [!NOTE]
 > The container image includes pre-installed dependencies for more providers than are present in the default runtime configuration (`config.yaml`). Providers such as `inline::sentence-transformers`, `inline::milvus`, and `inline::faiss` are available as dependencies but are stripped from the default `config.yaml`. The full provider manifest is maintained in `build.yaml`. To use these dependency-only providers, pass a custom `config.yaml` at runtime (as shown above) that includes the desired provider definitions. See the [distribution README](distribution/README.md) for which providers are dependency-only.
 
-## Weekly Responses API Tests
+## Responses API Tests
 
-A weekly orchestrator workflow (`responses-weekly.yml`) runs upstream Responses API integration tests against the distro image every Sunday at 22:00 UTC across all configured providers, then publishes an interactive test report to [GitHub Pages](https://opendatahub-io.github.io/ogx-distribution/).
+An orchestrator workflow (`responses-weekly.yml` / "Responses: Test Report") runs upstream Responses API integration tests against the distro image every Sunday at 22:00 UTC across all configured providers, then publishes an interactive test report to [GitHub Pages](https://opendatahub-io.github.io/ogx-distribution/).
 
-| Provider | Text models | Embedding model |
-|----------|-------------|-----------------|
-| OpenAI | gpt-4o-mini, gpt-4o, o4-mini | text-embedding-3-small |
-| Vertex AI | gemini-2.0-flash | gemini-embedding-2 |
-| vLLM MaaS | llama-3-2-3b | nomic-embed-text-v1-5 |
+| Provider | Default text model | Embedding model | Workflow |
+|----------|--------------------|-----------------|----------|
+| OpenAI | gpt-4.1-nano | text-embedding-3-small | `responses-openai.yml` |
+| Vertex AI | gemini-2.0-flash | gemini-embedding-2 | `responses-vertexai.yml` |
+| vLLM MaaS | llama-3-2-3b | nomic-embed-text-v1-5 | `responses-vllm-maas.yml` |
 
 ### How it works
 
 1. Each provider's credentials are checked; providers without secrets are skipped gracefully
-2. The shared `responses-run.yml` reusable workflow pulls the distro image, starts PostgreSQL (with pgvector) and the server container
-3. Upstream `tests/integration/responses/` are run with pytest per model, producing JUnit XML results
-4. A [test report](https://opendatahub-io.github.io/ogx-distribution/) with trend charts (by provider and by model) and a model breakdown table is deployed to GitHub Pages
-5. JUnit results are also published as GitHub Check annotations via [dorny/test-reporter](https://github.com/dorny/test-reporter)
+2. Each per-provider workflow (`responses-openai.yml`, `responses-vertexai.yml`, `responses-vllm-maas.yml`) pulls the distro image, starts PostgreSQL (with pgvector) and the server via the `setup-server` composite action
+3. Models run in parallel via GitHub Actions matrix strategy — each model gets its own job
+4. Upstream `tests/integration/responses/` are run with pytest in `--inference-mode=live`, producing JUnit XML results
+5. The orchestrator collects all artifacts and deploys a [test report](https://opendatahub-io.github.io/ogx-distribution/) with trend charts (by provider and by model) and a model breakdown table to GitHub Pages
+6. JUnit results are also published as GitHub Check annotations via [dorny/test-reporter](https://github.com/dorny/test-reporter)
 
 ### Test report
 
@@ -96,20 +97,20 @@ The report is a static HTML dashboard (no backend) with:
 - **Trend by Provider** and **Trend by Model** line charts showing passed test counts per OGX release (linked: clicking a provider filters the model chart)
 - **Model Breakdown** table with pass/fail/skip/error counts per provider and model
 - **Run History** table with links to GitHub Actions runs
-- History is kept for the last 20 runs
+- Branch-isolated history: `main` deploys to root, other branches to `preview/<branch>/` (last 20 runs each)
 
 ### Triggers
 
 | Trigger | Scope | Report location |
 |---------|-------|-----------------|
 | `schedule` (Sunday 22:00 UTC) | Runs from `main` | Root (`/`) |
-| `workflow_dispatch` | Any branch | `preview/<branch>/` for non-main branches |
+| `workflow_dispatch` | Any branch, per-provider toggles, model overrides | `preview/<branch>/` for non-main branches |
 
-Individual provider workflows (`responses-openai.yml`, etc.) can also be triggered manually via `workflow_dispatch` for on-demand runs without the report.
+Individual provider workflows can also be triggered manually via `workflow_dispatch` for on-demand runs (tests only, no report deployment).
 
 ### Adding providers and models
 
-To add a model: add an entry to `models_json` (text) or update `embedding_model` in the provider workflow. To add a provider: create a new caller workflow following the existing pattern and add the provider job to `responses-weekly.yml`. The report template is fully dynamic — new providers and models appear automatically.
+To override models: pass comma-separated model IDs via the `models` input when dispatching a provider workflow or the orchestrator. To add a provider: create a new per-provider workflow following the existing pattern and add the provider job to `responses-weekly.yml`. The report template is fully dynamic — new providers and models appear automatically.
 
 ### Required Secrets
 

--- a/scripts/junit_stats.py
+++ b/scripts/junit_stats.py
@@ -1,0 +1,88 @@
+"""Parse JUnit XML results into structured test statistics.
+
+Provides ``parse_results`` to scan a directory of JUnit XML files and
+return aggregated test statistics.  Used as a library by
+``junit_to_history.py`` to build the history file and optional stats
+artifact.
+
+Filename convention
+-------------------
+Each XML file is expected to match ``results_<provider>_<model>.xml``.
+Files that don't match are silently skipped.
+
+Return value of ``parse_results``
+---------------------------------
+``None`` when no valid results are found, otherwise a dict::
+
+    {
+        "models": [
+            {"provider": "openai", "model": "gpt-4o-mini",
+             "passed": 28, "failed": 2, "skipped": 0, "error": 0},
+            ...
+        ],
+        "totals": {"passed": 142, "failed": 5, "skipped": 3, "error": 0},
+        "providers": 3,
+        "total": 150,
+        "pass_pct": "94.7",
+    }
+"""
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from glob import glob
+from pathlib import Path
+
+FILENAME_RE = re.compile(r"results_(?P<provider>[^_]+(?:-[^_]+)*)_(?P<model>.+)\.xml")
+
+
+def parse_results(results_dir: str) -> dict | None:
+    """Scan *results_dir* for JUnit XML files and return aggregated stats.
+
+    Returns ``None`` when no matching XML files are found or all files
+    have unrecognised filenames.
+    """
+    xml_files = sorted(glob(os.path.join(results_dir, "**", "*.xml"), recursive=True))
+    if not xml_files:
+        return None
+
+    models = []
+    totals = {"passed": 0, "failed": 0, "skipped": 0, "error": 0}
+
+    for xml_path in xml_files:
+        m = FILENAME_RE.match(Path(xml_path).name)
+        if not m:
+            continue
+
+        counts = {"passed": 0, "failed": 0, "skipped": 0, "error": 0}
+        tree = ET.parse(xml_path)
+        for suite in tree.getroot().iter("testsuite"):
+            for tc in suite.findall("testcase"):
+                if tc.find("failure") is not None:
+                    counts["failed"] += 1
+                elif tc.find("error") is not None:
+                    counts["error"] += 1
+                elif tc.find("skipped") is not None:
+                    counts["skipped"] += 1
+                else:
+                    counts["passed"] += 1
+
+        entry = {"provider": m.group("provider"), "model": m.group("model"), **counts}
+        models.append(entry)
+        for k in totals:
+            totals[k] += counts[k]
+
+    if not models:
+        return None
+
+    total = sum(totals.values())
+    providers = len(set(e["provider"] for e in models))
+    pct = f"{totals['passed'] / total * 100:.1f}" if total else "0.0"
+
+    return {
+        "models": models,
+        "totals": totals,
+        "providers": providers,
+        "total": total,
+        "pass_pct": pct,
+    }

--- a/scripts/junit_to_history.py
+++ b/scripts/junit_to_history.py
@@ -1,50 +1,30 @@
 #!/usr/bin/env python3
-"""Parse JUnit XML results and append to history.json for the test report."""
+"""Parse JUnit XML results and append to history.json for the test report.
+
+Uses ``junit_stats.parse_results`` for the actual XML parsing and then
+builds a timestamped run entry for the trend-chart history file.
+
+An optional fourth argument writes the raw stats dict to a JSON file
+so downstream workflow steps (e.g. Slack notifications) can consume it
+without re-parsing the XML.
+"""
 
 import json
 import os
-import re
 import sys
-import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
-from glob import glob
-from pathlib import Path
 
-FILENAME_RE = re.compile(r"results_(?P<provider>[^_]+(?:-[^_]+)*)_(?P<model>.+)\.xml")
-
-
-def parse_junit(xml_path: str) -> dict:
-    """Parse a single JUnit XML file and return summary + per-test data."""
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-
-    fname = Path(xml_path).name
-    m = FILENAME_RE.match(fname)
-    provider = m.group("provider") if m else "unknown"
-    file_model = m.group("model") if m else "unknown"
-
-    counts = {"passed": 0, "failed": 0, "skipped": 0, "error": 0}
-    for suite in root.iter("testsuite"):
-        for tc in suite.findall("testcase"):
-            if tc.find("failure") is not None:
-                counts["failed"] += 1
-            elif tc.find("error") is not None:
-                counts["error"] += 1
-            elif tc.find("skipped") is not None:
-                counts["skipped"] += 1
-            else:
-                counts["passed"] += 1
-
-    return {"provider": provider, "model": file_model, **counts}
+from junit_stats import parse_results
 
 
 def main():
     results_dir = sys.argv[1]
     history_file = sys.argv[2]
     output_file = sys.argv[3]
+    stats_file = sys.argv[4] if len(sys.argv) > 4 else None
 
-    xml_files = sorted(glob(os.path.join(results_dir, "**", "*.xml"), recursive=True))
-    if not xml_files:
+    stats = parse_results(results_dir)
+    if stats is None:
         print("No JUnit XML files found, writing empty history", file=sys.stderr)
         history = []
         if os.path.exists(history_file) and os.path.getsize(history_file) > 0:
@@ -53,20 +33,6 @@ def main():
         with open(output_file, "w") as f:
             json.dump(history, f, indent=2)
         sys.exit(0)
-
-    models = []
-    totals = {"passed": 0, "failed": 0, "skipped": 0, "error": 0}
-    for xf in xml_files:
-        entry = parse_junit(xf)
-        if entry["provider"] == "unknown":
-            print(
-                f"  Skipping {Path(xf).name}: filename does not match expected pattern",
-                file=sys.stderr,
-            )
-            continue
-        models.append(entry)
-        for k in totals:
-            totals[k] += entry[k]
 
     run = {
         "date": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
@@ -79,8 +45,8 @@ def main():
         "ogx_version": os.environ.get("OGX_VERSION", ""),
         "branch": os.environ.get("GITHUB_REF_NAME", ""),
         "commit": os.environ.get("GITHUB_SHA", "")[:8],
-        "totals": totals,
-        "models": models,
+        "totals": stats["totals"],
+        "models": stats["models"],
     }
 
     history = []
@@ -98,11 +64,9 @@ def main():
     with open(output_file, "w") as f:
         json.dump(history, f, indent=2)
 
-    print(f"Parsed {len(xml_files)} XML files, {sum(totals.values())} tests total")
-    for m in models:
-        print(
-            f"  {m['provider']}/{m['model']}: {m['passed']}P {m['failed']}F {m['skipped']}S {m['error']}E"
-        )
+    if stats_file:
+        with open(stats_file, "w") as f:
+            json.dump(stats, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/scripts/junit_to_history.py
+++ b/scripts/junit_to_history.py
@@ -45,7 +45,13 @@ def main():
 
     xml_files = sorted(glob(os.path.join(results_dir, "**", "*.xml"), recursive=True))
     if not xml_files:
-        print("No JUnit XML files found", file=sys.stderr)
+        print("No JUnit XML files found, writing empty history", file=sys.stderr)
+        history = []
+        if os.path.exists(history_file) and os.path.getsize(history_file) > 0:
+            with open(history_file) as f:
+                history = json.load(f)
+        with open(output_file, "w") as f:
+            json.dump(history, f, indent=2)
         sys.exit(0)
 
     models = []

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,7 +57,7 @@ Integration tests run the upstream [ogx pytest suite](https://github.com/ogx/ogx
 2. **Clones the ogx repository** at the matching version tag into `/tmp/ogx-integration-tests`.
 3. **Runs `pytest`** against `tests/integration/inference/` with required test dependencies installed, pointing at `distribution/config.yaml`.
    - `ogx-client` is required.
-   - `ollama` is explicitly installed because the upstream test fixtures import it, even though this distribution does not use Ollama as a provider.
+   - `ollama` is explicitly installed because the upstream test fixtures import it unconditionally (see [ogx-ai/ogx#5880](https://github.com/ogx-ai/ogx/issues/5880)).
 
 Tests are run for each configured inference model (vLLM, and optionally Vertex AI and OpenAI).
 


### PR DESCRIPTION
## Summary

Follow-up to #249 addressing reviewer feedback and adding model parallelization.

### Changes

- **Parallelize model tests** — each model now runs in its own GitHub Actions matrix job instead of sequentially in a loop, significantly speeding up multi-model runs (`responses-openai.yml`, `responses-vertexai.yml`, `responses-vllm-maas.yml`)
- **Configurable model lists** — default models per provider are now read from GitHub repo variables (`TEST_MODELS_OPENAI`, `TEST_MODELS_VERTEXAI`, `TEST_MODELS_VLLM_MAAS`) as comma-separated lists, falling back to a single hardcoded model if unset
- **Rename orchestrator** — "Responses: Weekly Report" → "Responses: Test Report" to reflect purpose over schedule
- **Wire `image_tag` input** — manual dispatch now actually uses the `image_tag` override; `workflow_call` falls back to the pinned tag
- **Fix no-results deploy** — `junit_to_history.py` now preserves existing `history.json` when no JUnit XMLs are found instead of deploying a broken page
- **Update README** — matches current per-provider workflow architecture, removes stale references to `responses-run.yml` and `models_json`
- **Remove explicit `ollama`** from pip install — it's a declared dependency of ogx and installed transitively (see ogx-ai/ogx#5880)
- **Harden CI workflows** — move `${{ }}` expressions from `run:` blocks into step-level `env:` entries to prevent script injection; remove unused `id-token: write` permission from openai/vllm-maas test jobs; pin upstream test repo clone to commit SHA

### Repo variables to configure

| Variable | Example value |
|---|---|
| `TEST_MODELS_OPENAI` | `openai/gpt-4.1-nano,openai/gpt-4.1` |
| `TEST_MODELS_VERTEXAI` | `vertexai/publishers/google/models/gemini-2.0-flash,vertexai/publishers/google/models/gemini-2.5-pro` |
| `TEST_MODELS_VLLM_MAAS` | `vllm-inference/Qwen3.6-35B-A3B` |

## Test plan

- [x] Pre-commit passes
- [x] Matrix parallelization: trigger with multiple models, verify parallel jobs in Actions UI
- [x] Artifact merge: verify report correctly aggregates results from matrix jobs
- [x] `image_tag` override: dispatch with custom tag, verify correct image is pulled

🤖 Generated with [Claude Code](https://claude.com/claude-code)