### PR TITLE
feat: enable custom model registry refresh interval

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -197,16 +197,40 @@ def generate_stripped_config():
     print(f"Successfully generated {output_path}")
 
 
+def _resolve_env_defaults(text):
+    """Replace ${env.VAR:=default} and ${env.VAR:+value} templates.
+
+    Pydantic validates build.yaml before env-var substitution, so
+    non-string fields (e.g. integers) must contain plain values.
+    Empty defaults are quoted to avoid YAML null interpretation.
+    """
+
+    def _replace_default(match):
+        default = match.group(1)
+        return f'"{default}"' if default == "" else default
+
+    text = re.sub(r"\$\{env\.[^:}]+:=([^}]*)\}", _replace_default, text)
+    text = re.sub(r"\$\{env\.[^:}]+:\+([^}]*)\}", r'"\1"', text)
+    return text
+
+
 def get_dependencies(ogx_bin: Path) -> list[str]:
     """Execute the ogx list-deps command and return a list of package specifiers."""
-    cmd = [str(ogx_bin), "stack", "list-deps", "build/build.yaml"]
+    build_yaml = Path("build/build.yaml")
+    resolved = _resolve_env_defaults(build_yaml.read_text())
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        tmp.write(resolved)
+        tmp_path = tmp.name
     try:
+        cmd = [str(ogx_bin), "stack", "list-deps", tmp_path]
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     except subprocess.CalledProcessError as e:
         print(f"Error executing command: {e}")
         print(f"Command output: {e.output}")
         print(f"Command stderr: {e.stderr}")
         sys.exit(1)
+    finally:
+        os.unlink(tmp_path)
 
     packages = []
     for line in result.stdout.splitlines():

--- a/build/build.yaml
+++ b/build/build.yaml
@@ -244,6 +244,7 @@ telemetry:
   enabled: true
 server:
   port: 8321
+  registry_refresh_interval_seconds: ${env.REGISTRY_REFRESH_INTERVAL_SECONDS:=300}
   auth:
     provider_config:
       type: ${env.AUTH_ISSUER:+oauth2_token}

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -234,6 +234,7 @@ telemetry:
   enabled: true
 server:
   port: 8321
+  registry_refresh_interval_seconds: ${env.REGISTRY_REFRESH_INTERVAL_SECONDS:=300}
   auth:
     provider_config:
       type: ${env.AUTH_ISSUER:+oauth2_token}


### PR DESCRIPTION
# What does this PR do?
OGX offers the ability for server admins to configure the interval in which OGX refreshes its model registry

This is useful behavior to expose to our customers who may not want to use the default value of 300 seconds

## Test Plan
Tested upstream, this is just a configuration exposure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `registry_refresh_interval_seconds` setting to control registry update frequency. Defaults to 300 seconds and can be customized via the `REGISTRY_REFRESH_INTERVAL_SECONDS` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->