### PR TITLE
feat: pre-download granite embedding model

### DIFF
--- a/distribution/install-common.sh
+++ b/distribution/install-common.sh
@@ -7,3 +7,6 @@ mkdir -p "${HOME}/.ogx" "${HOME}/.cache"
 # from openaipublic.blob.core.windows.net (used by vector_store chunking)
 export TIKTOKEN_CACHE_DIR="${HOME}/.cache/tiktoken"
 python3 -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+
+# Pre-download the embedding model
+hf download ibm-granite/granite-embedding-125m-english


### PR DESCRIPTION
# What does this PR do?

Pre-downloads `ibm-granite/granite-embedding-125m-english` to enable offline operation when creating vector stores.

This aligns the midstream with the [downstream Dockerfile change](https://github.com/red-hat-data-services/ogx-distribution/blob/8f2d9d17dcd01a956ae9304c3320ecd5f6975466/Dockerfile.konflux#L52) and allows the image to work in air-gapped/offline environments.

Resolves: [RHOAIENG-63761](https://redhat.atlassian.net/browse/RHOAIENG-63761)

## Test Plan

### Build and Push
1. Built AMD64 image locally with Colima/Docker buildx
2. Verified embedding model download in build logs (step 14/12):
   ```
   Fetching 14 files: 100%|██████████| 14/14 [00:32<00:00,  2.33s/it]
   ✓ Downloaded
   path: /opt/app-root/src/.cache/huggingface/hub/models--ibm-granite--granite-embedding-125m-english/snapshots/4ab61ffd423be45cd932b21a7c696063d82bf45f
   ```
3. Pushed to Quay: `quay.io/rh-ee-ngagan/llama-stack:embedding-model`

### Offline Validation
1. Deployed image to cluster
2. Set offline environment variables:
   - `HF_HUB_OFFLINE=1`
   - `TRANSFORMERS_OFFLINE=1`
   - `HF_DATASETS_OFFLINE=1`
3. Created vector store
4. ✅ Verified Hugging Face was NOT called (confirmed model loaded from cache)

**Result:** The embedding model is successfully pre-cached and available for offline use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation efficiency by pre-downloading the embedding model during the build process, reducing initial runtime setup time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->