### PR TITLE
feat: use Bearer token auth for Gemini testing via WIF

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -223,18 +223,19 @@ jobs:
 
       - name: Authenticate to Google Cloud (Gemini)
         if: env.USE_GEMINI_BEARER == 'true' && matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
-        id: gcp-auth-gemini
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: ${{ env.GEMINI_AI_PROJECT }}
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          token_format: 'access_token'
+
+      - name: Set up Google Cloud SDK (Gemini)
+        if: env.USE_GEMINI_BEARER == 'true' && matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Gemini auth
         if: env.USE_GEMINI_BEARER == 'true'
-        env:
-          GEMINI_TOKEN: ${{ steps.gcp-auth-gemini.outputs.access_token }}
         run: |
+          GEMINI_TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
           if [ -n "$GEMINI_TOKEN" ]; then
             echo "Gemini: Bearer token obtained, using OAuth/ADC auth"
             {

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -221,13 +221,6 @@ jobs:
           project_id: ${{ env.VERTEX_AI_PROJECT }}
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
-      - name: Authenticate to Google Cloud (Gemini)
-        if: env.USE_GEMINI_BEARER == 'true' && matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          project_id: ${{ env.GEMINI_AI_PROJECT }}
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
       - name: Set up Google Cloud SDK (Gemini)
         if: env.USE_GEMINI_BEARER == 'true' && matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
@@ -235,8 +228,9 @@ jobs:
       - name: Configure Gemini auth
         if: env.USE_GEMINI_BEARER == 'true'
         run: |
-          GEMINI_TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
+          GEMINI_TOKEN=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever 2>/dev/null || true)
           if [ -n "$GEMINI_TOKEN" ]; then
+            echo "::add-mask::$GEMINI_TOKEN"
             echo "Gemini: Bearer token obtained, using OAuth/ADC auth"
             {
               echo "ENABLE_GEMINI=1"

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -60,6 +60,7 @@ jobs:
     env:
       VERTEX_AI_PROJECT: ${{ secrets.VERTEX_AI_PROJECT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GEMINI_AI_PROJECT: ${{ secrets.GEMINI_AI_PROJECT }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Model names - set defaults, overridden by MaaS configuration step
@@ -163,12 +164,15 @@ jobs:
             fi
           fi
 
-          # Gemini: validate key with a lightweight call
-          if [ -n "$GEMINI_API_KEY" ]; then
+          # Gemini: prefer Bearer token via WIF, fall back to API key
+          if [ -n "$GEMINI_AI_PROJECT" ] && [ -n "$GCP_WORKLOAD_IDENTITY_PROVIDER" ]; then
+            echo "Gemini: will attempt Bearer token auth via WIF"
+            echo "USE_GEMINI_BEARER=true" >> "$GITHUB_ENV"
+          elif [ -n "$GEMINI_API_KEY" ]; then
             status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 \
               "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY")
             if [ "$status" != "200" ]; then
-              echo "::warning::Gemini API returned HTTP $status, skipping Gemini tests"
+              echo "::warning::Gemini API key returned HTTP $status, skipping Gemini tests"
               { echo "GEMINI_API_KEY="; echo "ENABLE_GEMINI="; } >> "$GITHUB_ENV"
             else
               echo "ENABLE_GEMINI=1" >> "$GITHUB_ENV"
@@ -216,6 +220,37 @@ jobs:
         with:
           project_id: ${{ env.VERTEX_AI_PROJECT }}
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Authenticate to Google Cloud (Gemini)
+        if: env.USE_GEMINI_BEARER == 'true' && matrix.arch == 'amd64' && github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.secret_source != 'Dependabot'))
+        id: gcp-auth-gemini
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: ${{ env.GEMINI_AI_PROJECT }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          token_format: 'access_token'
+
+      - name: Configure Gemini auth
+        if: env.USE_GEMINI_BEARER == 'true'
+        env:
+          GEMINI_TOKEN: ${{ steps.gcp-auth-gemini.outputs.access_token }}
+        run: |
+          if [ -n "$GEMINI_TOKEN" ]; then
+            echo "Gemini: Bearer token obtained, using OAuth/ADC auth"
+            {
+              echo "ENABLE_GEMINI=1"
+              echo "GEMINI_ACCESS_TOKEN=$GEMINI_TOKEN"
+              echo "GEMINI_AI_PROJECT=$GEMINI_AI_PROJECT"
+              echo "GEMINI_API_KEY="
+            } >> "$GITHUB_ENV"
+          elif [ -n "$GEMINI_API_KEY" ]; then
+            echo "::warning::Gemini Bearer token auth failed, falling back to API key"
+            echo "ENABLE_GEMINI=1" >> "$GITHUB_ENV"
+            echo "USE_GEMINI_BEARER=" >> "$GITHUB_ENV"
+          else
+            echo "::warning::No Gemini credentials available, skipping Gemini tests"
+            echo "ENABLE_GEMINI=" >> "$GITHUB_ENV"
+          fi
 
       - name: Setup vLLM inference container
         if: github.event_name != 'workflow_dispatch' && env.USING_MAAS != 'true'

--- a/.github/workflows/responses-gemini.yml
+++ b/.github/workflows/responses-gemini.yml
@@ -1,0 +1,154 @@
+name: "Responses: Gemini"
+
+on:
+  workflow_call:
+    inputs:
+      models:
+        description: 'Comma-separated model IDs to test (leave empty for defaults)'
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to test (default: latest)'
+        required: false
+        default: 'latest'
+        type: string
+      models:
+        description: 'Comma-separated model IDs to test (default: all)'
+        required: false
+        type: string
+
+env:
+  PROVIDER_NAME: gemini
+  EMBEDDING_MODEL: gemini/models/gemini-embedding-2
+  IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
+  IMAGE_TAG: source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+      models_json: ${{ steps.models.outputs.json }}
+    steps:
+      - name: Check Gemini credentials
+        id: check
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          if [ -z "$GEMINI_API_KEY" ]; then
+            echo "::warning::GEMINI_API_KEY not configured, skipping tests"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Resolve models
+        id: models
+        run: |
+          default='["gemini/models/gemini-2.5-flash"]'
+          input='${{ inputs.models }}'
+          if [ -z "$input" ]; then
+            echo "json=$default" >> "$GITHUB_OUTPUT"
+          else
+            echo "json=$(echo "$input" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: check
+    if: needs.check.outputs.enabled == 'true'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(needs.check.outputs.models_json) }}
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: 3.12
+          enable-cache: false
+
+      - name: Setup PostgreSQL
+        uses: ./.github/actions/setup-postgres
+
+      - name: Setup server
+        uses: ./.github/actions/setup-server
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          extra_env: |
+            ENABLE_GEMINI=1
+            GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+            TAVILY_SEARCH_API_KEY=${{ secrets.TAVILY_SEARCH_API_KEY }}
+            EMBEDDING_MODEL=gemini/models/gemini-embedding-2
+            EMBEDDING_PROVIDER=gemini
+            EMBEDDING_PROVIDER_MODEL_ID=models/gemini-embedding-2
+
+      - name: Clone upstream tests
+        shell: bash
+        run: |
+          git clone --branch v1.0.0 --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
+          cd /tmp/ogx-tests
+
+          uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e . ogx-client ollama pytest langchain-openai langgraph
+
+      - name: Derive short model name
+        id: model
+        run: |
+          full='${{ matrix.model }}'
+          echo "short=${full##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Run responses tests
+        shell: bash
+        run: |
+          cd /tmp/ogx-tests
+          source .venv/bin/activate
+          mkdir -p /tmp/test-results
+
+          SKIP_TESTS="test_response_connector_resolution_mcp_tool"
+          MODEL='${{ matrix.model }}'
+          SHORT='${{ steps.model.outputs.short }}'
+
+          python -m pytest -s -v tests/integration/responses/ \
+            -k "not ($SKIP_TESTS)" \
+            --stack-config=server:"$GITHUB_WORKSPACE/distribution/config.yaml" \
+            --text-model="$MODEL" \
+            --embedding-model="$EMBEDDING_MODEL" \
+            --inference-mode=live \
+            --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
+            || [ $? -eq 5 ]
+
+      - name: Publish test report
+        if: always()
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
+          path: /tmp/test-results/*.xml
+          reporter: java-junit
+          fail-on-error: 'false'
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}
+          path: /tmp/test-results/
+          retention-days: 90
+
+      - name: Cleanup
+        if: always()
+        run: |
+          for c in ogx postgres; do
+            docker rm -f "$c" 2>/dev/null || true
+          done

--- a/.github/workflows/responses-weekly.yml
+++ b/.github/workflows/responses-weekly.yml
@@ -63,7 +63,7 @@ jobs:
 
   # ── Gemini ──────────────────────────────────────────────────────
   test-gemini:
-    if: inputs.run_gemini != false
+    if: github.event_name == 'schedule' || inputs.run_gemini != false
     uses: ./.github/workflows/responses-gemini.yml
     with:
       models: ${{ inputs.gemini_models }}

--- a/.github/workflows/responses-weekly.yml
+++ b/.github/workflows/responses-weekly.yml
@@ -21,6 +21,14 @@ on:
         description: 'Vertex AI models (comma-separated, leave empty for defaults)'
         type: string
         default: ''
+      run_gemini:
+        description: 'Run Gemini tests'
+        type: boolean
+        default: true
+      gemini_models:
+        description: 'Gemini models (comma-separated, leave empty for defaults)'
+        type: string
+        default: ''
       run_vllm_maas:
         description: 'Run vLLM MaaS tests'
         type: boolean
@@ -53,6 +61,14 @@ jobs:
       models: ${{ inputs.vertexai_models }}
     secrets: inherit
 
+  # ── Gemini ──────────────────────────────────────────────────────
+  test-gemini:
+    if: inputs.run_gemini != false
+    uses: ./.github/workflows/responses-gemini.yml
+    with:
+      models: ${{ inputs.gemini_models }}
+    secrets: inherit
+
   # ── vLLM MaaS ──────────────────────────────────────────────────
   test-vllm-maas:
     if: github.event_name == 'schedule' || inputs.run_vllm_maas != false
@@ -65,8 +81,8 @@ jobs:
   report:
     name: Publish Test Report
     runs-on: ubuntu-24.04
-    if: ${{ !cancelled() }}
-    needs: [test-openai, test-vertexai, test-vllm-maas]
+    if: always()
+    needs: [test-openai, test-vertexai, test-gemini, test-vllm-maas]
 
     steps:
       - name: Checkout repository

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -103,6 +103,7 @@ function main() {
     echo "  VERTEX_AI_PROJECT: ${VERTEX_AI_PROJECT:-<not set>}"
     echo "  OPENAI_API_KEY: ${OPENAI_API_KEY:+<set>}"
     echo "  GEMINI_API_KEY: ${GEMINI_API_KEY:+<set>}"
+    echo "  GEMINI_ACCESS_TOKEN: ${GEMINI_ACCESS_TOKEN:+<set>}"
 
     clone_ogx
 
@@ -126,12 +127,12 @@ function main() {
         echo "OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY is set
-    if [ -n "${GEMINI_API_KEY:-}" ]; then
-        echo "GEMINI_API_KEY is set, including Gemini models in tests"
+    # Only include Gemini models if credentials (Bearer token or API key) are set
+    if [ -n "${GEMINI_ACCESS_TOKEN:-}" ] || [ -n "${GEMINI_API_KEY:-}" ]; then
+        echo "Gemini credentials available, including Gemini models in tests"
         models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-        echo "GEMINI_API_KEY is not set, skipping Gemini models"
+        echo "Gemini credentials not available, skipping Gemini models"
     fi
 
     for model in "${models_to_test[@]}"; do

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -58,8 +58,14 @@ function start_and_wait_for_ogx_container {
     docker_args+=(--env "OPENAI_API_KEY=$OPENAI_API_KEY")
   fi
 
-  # Only add Gemini configuration if GEMINI_API_KEY is set
-  if [ -n "${GEMINI_API_KEY:-}" ]; then
+  # Add Gemini configuration: prefer Bearer token (access token), fall back to API key
+  if [ -n "${GEMINI_ACCESS_TOKEN:-}" ] && [ -n "${GEMINI_AI_PROJECT:-}" ]; then
+    docker_args+=(
+      --env "ENABLE_GEMINI=1"
+      --env "GEMINI_ACCESS_TOKEN=$GEMINI_ACCESS_TOKEN"
+      --env "GEMINI_AI_PROJECT=$GEMINI_AI_PROJECT"
+    )
+  elif [ -n "${GEMINI_API_KEY:-}" ]; then
     docker_args+=(
       --env "ENABLE_GEMINI=1"
       --env "GEMINI_API_KEY=$GEMINI_API_KEY"
@@ -250,13 +256,13 @@ main() {
       echo "===> OPENAI_API_KEY is not set, skipping OpenAI models"
     fi
 
-    # Only include Gemini models if GEMINI_API_KEY is set
-    if [ -n "${GEMINI_API_KEY:-}" ]; then
-      echo "===> GEMINI_API_KEY is set, including Gemini models in tests"
+    # Only include Gemini models if credentials (Bearer token or API key) are set
+    if [ -n "${GEMINI_ACCESS_TOKEN:-}" ] || [ -n "${GEMINI_API_KEY:-}" ]; then
+      echo "===> Gemini credentials available, including Gemini models in tests"
       models_to_test+=("$GEMINI_INFERENCE_MODEL")
       inference_models_to_test+=("$GEMINI_INFERENCE_MODEL")
     else
-      echo "===> GEMINI_API_KEY is not set, skipping Gemini models"
+      echo "===> Gemini credentials not available, skipping Gemini models"
     fi
 
     echo "===> Testing model list for all models..."


### PR DESCRIPTION
# What does this PR do?
Prefer WIF-based Bearer token auth (GEMINI_ACCESS_TOKEN) over API key for Gemini provider testing in CI, with automatic fallback to API key when WIF credentials are unavailable.

Closes #405

## Test Plan
Test via CI, still need to work out some details around the SA with @courtneypacheco 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable CI workflow to run Gemini response integration tests and a weekly option to include Gemini model runs.

* **Improvements**
  * Support for Gemini Bearer (Workload Identity) or API-key authentication with automatic detection, token acquisition, and fallbacks.
  * CI test and smoke runners now accept either a Gemini access token or API key and report when an access token is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->