### PR TITLE
chore: add dependabot docker ecosystem for vllm base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,14 @@ updates:
       - python
     commit-message:
       prefix: chore(python-deps)
+  # Enable version updates for vLLM base container image
+  - package-ecosystem: "docker"
+    directory: "/vllm"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    labels:
+      - type/dependencies
+      - vllm
+    commit-message:
+      prefix: chore(vllm)

--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -2,7 +2,7 @@
 #
 # Reference: https://hub.docker.com/r/vllm/vllm-openai-cpu
 
-FROM vllm/vllm-openai-cpu:v0.21.0
+FROM vllm/vllm-openai-cpu:v0.22.0
 
 RUN pip install "huggingface-hub[cli]"
 


### PR DESCRIPTION
# What does this PR do?
Dependabot now natively supports Containerfile (https://github.com/dependabot/dependabot-core/issues/6067),
so adding a docker ecosystem entry for the vllm/ directory will automatically
open PRs when new vllm/vllm-openai-cpu tags are published.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to latest compatible version for improved stability.
  * Configured automated dependency updates for infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->