### PR TITLE
fix: gemini model name to gemini-2.5-flash

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -64,7 +64,7 @@ jobs:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       # Model names - set defaults, overridden by MaaS configuration step
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.0-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-5-nano
       GEMINI_INFERENCE_MODEL: gemini/models/gemini-2.5-flash
       EMBEDDING_MODEL: vllm-embedding/ibm-granite/granite-embedding-125m-english

--- a/.github/workflows/responses-vertexai.yml
+++ b/.github/workflows/responses-vertexai.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           INPUT_MODELS: ${{ inputs.models || vars.TEST_MODELS_VERTEXAI }}
         run: |
-          default='["vertexai/publishers/google/models/gemini-2.0-flash"]'
+          default='["vertexai/publishers/google/models/gemini-2.5-flash"]'
           if [ -z "$INPUT_MODELS" ]; then
             echo "json=$default" >> "$GITHUB_OUTPUT"
           else

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ An orchestrator workflow (`responses-weekly.yml` / "Responses: Test Report") run
 | Provider | Default text model | Embedding model | Workflow |
 |----------|--------------------|-----------------|----------|
 | OpenAI | gpt-4.1-nano | text-embedding-3-small | `responses-openai.yml` |
-| Vertex AI | gemini-2.0-flash | gemini-embedding-2 | `responses-vertexai.yml` |
+| Vertex AI | gemini-2.5-flash | gemini-embedding-2 | `responses-vertexai.yml` |
 | vLLM MaaS | llama-3-2-3b | nomic-embed-text-v1-5 | `responses-vllm-maas.yml` |
 
 ### How it works

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,7 +27,7 @@ Models tested depend on available credentials:
 |-------|---------------------|---------------|
 | vLLM inference model (`vllm-inference/Qwen/Qwen3-0.6B`) | `VLLM_INFERENCE_MODEL` | Yes |
 | Embedding model (`vllm-embedding/ibm-granite/granite-embedding-125m-english`) | `EMBEDDING_MODEL` | Yes (list only) |
-| Vertex AI model (`vertexai/publishers/google/models/gemini-2.0-flash`) | `VERTEX_AI_PROJECT` | Only if set |
+| Vertex AI model (`vertexai/publishers/google/models/gemini-2.5-flash`) | `VERTEX_AI_PROJECT` | Only if set |
 | OpenAI model (`openai/gpt-5-nano`) | `OPENAI_API_KEY` | Only if set |
 
 #### Running locally


### PR DESCRIPTION
## What does this PR do?

Updates the Vertex AI model reference from `gemini-2.0-flash` to `gemini-2.5-flash` across CI workflows and documentation.

### Changed files
- `.github/workflows/redhat-distro-container.yml` — default `VERTEX_AI_INFERENCE_MODEL`
- `.github/workflows/responses-vertexai.yml` — default model list fallback
- `README.md` — provider table
- `tests/README.md` — model matrix table

## Test Plan

- CI workflows will pick up the new model name on next run
- No logic changes — string replacement only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Vertex AI language model used in CI/CD workflows for container builds and integration tests to a newer version.

* **Documentation**
  * Updated test and deployment documentation to reflect the new default model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->