### PR TITLE
feat: add remote::anthropic provider to distro config

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -15,6 +15,7 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | files | inline::localfs | No | ✅ | N/A |
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | Dependency only* | Requires a custom `config.yaml` |
+| inference | remote::anthropic | No | ❌ | Set the `ANTHROPIC_API_KEY` environment variable |
 | inference | remote::azure | No | ❌ | Set the `AZURE_API_KEY` environment variable |
 | inference | remote::bedrock | No | ❌ | Set the `AWS_BEARER_TOKEN_BEDROCK` environment variable |
 | inference | remote::gemini | No | ❌ | Set the `ENABLE_GEMINI` environment variable |

--- a/distribution/build.yaml
+++ b/distribution/build.yaml
@@ -62,6 +62,10 @@ providers:
       api_key: ${env.GEMINI_API_KEY:=}
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
+  - provider_id: ${env.ANTHROPIC_API_KEY:+anthropic}
+    provider_type: remote::anthropic
+    config:
+      api_key: ${env.ANTHROPIC_API_KEY:=}
   vector_io:
   - provider_id: milvus
     provider_type: inline::milvus

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -66,6 +66,10 @@ providers:
       api_key: ${env.GEMINI_API_KEY:=}
       access_token: ${env.GEMINI_ACCESS_TOKEN:=}
       project: ${env.GEMINI_AI_PROJECT:=}
+  - provider_id: ${env.ANTHROPIC_API_KEY:+anthropic}
+    provider_type: remote::anthropic
+    config:
+      api_key: ${env.ANTHROPIC_API_KEY:=}
   vector_io:
   - provider_id: ${env.MILVUS_ENDPOINT:+milvus-remote}
     provider_type: remote::milvus

--- a/distribution/install-deps.sh
+++ b/distribution/install-deps.sh
@@ -25,6 +25,7 @@ uv pip install \
     'pypdf>=6.7.2' \
     'sqlalchemy[asyncio]' \
     aiosqlite \
+    anthropic \
     asyncpg \
     boto3 \
     chardet \


### PR DESCRIPTION
## Summary
- Add Anthropic as a remote inference provider, following the same pattern as the existing Gemini/Azure/Bedrock providers
- Enabled by setting the `ANTHROPIC_API_KEY` environment variable
- Adds `anthropic` pip dependency to `install-deps.sh`

## Test plan
- [ ] Build the distribution image and verify it starts with `ANTHROPIC_API_KEY` set
- [ ] Verify inference requests route to Anthropic correctly
- [ ] Verify the provider is not registered when the env var is unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic as a new inference provider option (disabled by default). Enable it by setting the `ANTHROPIC_API_KEY` environment variable. Documentation and required dependencies have been included to support this integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->