### PR TITLE
fix: update showroom action to include embedding model fix

### DIFF
--- a/.github/workflows/test-pr-in-showroom.yml
+++ b/.github/workflows/test-pr-in-showroom.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Setup CI environment
         id: setup
-        uses: derekhiggins/llama-stack-showroom@fad3dfe273d55357107929e36eb031706456fe88  # main as of 2026-04-23
+        uses: derekhiggins/llama-stack-showroom@f32973c9b7389b14d1988b55abfe74dd98c2432f  # main as of 2026-06-05
         with:
           catalog_image: ${{ inputs.catalog_image }}
           llama_stack_image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-operator/ogx-test:${{ steps.build.outputs.tag }}"


### PR DESCRIPTION
## Summary
- Updates the pinned showroom action from `fad3dfe` to `f32973c` (current main)
- Includes the embedding model registration fix from llama-stack-showroom#45
- Fixes daily showroom CI which was failing with `Model 'vllm-embedding/nomic-ai/nomic-embed-text-v1.5' not found` on all RAG-related tests (3/6 demos failing)

## Test plan
- [x] Verified fix passes by pushing to `ntsh` branch and running the workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environment setup dependency reference to a more recent version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->