### PR TITLE
fix: add vector_stores to storage config

### DIFF
--- a/build/build.yaml
+++ b/build/build.yaml
@@ -230,6 +230,9 @@ storage:
     connectors:
       table_name: connectors
       backend: sql_default
+    vector_stores:
+      backend: sql_default
+      table_name: vector_store_metadata
 registered_resources:
   models:
   - metadata:

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -220,6 +220,9 @@ storage:
     connectors:
       table_name: connectors
       backend: sql_default
+    vector_stores:
+      backend: sql_default
+      table_name: vector_store_metadata
 registered_resources:
   models:
   - metadata:


### PR DESCRIPTION
## Summary

- OGX fails to start with `ValueError: metadata_store is required when access control policies are configured`
- Adds the missing `storage.stores.vector_stores` section to both `build/build.yaml` and `distribution/config.yaml`

## Test plan

- [ ] Start OGX with access control policies configured and verify no ValueError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration to add persistent vector storage, enabling consistent and durable vector metadata across deployments for improved data persistence and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->