### PR TITLE
feat: add functional test framework (Bruno CRUD + notebook runner)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ venv/
 pytest-report.xml
 .coverage
 .python-version
+node_modules/
+tests/functional/reports/
+tests/functional/uv.lock
+tests/functional/bruno/package-lock.json
+tests/functional/bruno/pnpm-lock.yaml

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,0 +1,85 @@
+# Functional Tests
+
+Functional tests for OGX distribution — Bruno API contracts + Jupyter notebook integration tests. Runs against any OGX deployment (local podman, Konflux ITS, RHOAI cluster).
+
+## Quick Start
+
+```bash
+# Start OGX + PostgreSQL + vLLM locally in a podman pod, run all tests, clean up
+cd tests/functional
+./scripts/setup-server.sh --its
+```
+
+Or point to an existing deployment:
+
+```bash
+cd tests/functional
+uv sync && cd bruno && npm ci && cd ..
+export BASE_URL="http://localhost:8321"
+export INFERENCE_MODEL="vllm-inference/llama-3-2-3b"
+./scripts/run-tests-with-providers.sh
+```
+
+Reports land in `reports/` as JUnit XML (`bruno-crud.xml`, `notebooks.xml`).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/setup-server.sh` | Start/stop local infra (podman). Use `--its` for full pod, `--start-only` / `--tests-only` / `--cleanup` for individual steps |
+| `scripts/run-tests-with-providers.sh` | Run Bruno CRUD + notebook tests against a running server. Requires `BASE_URL` and `INFERENCE_MODEL` |
+| `scripts/sync-client-version.sh` | Auto-sync `ogx-client` pip package to match the server version |
+| `scripts/bruno_summary.py` | Convert Bruno JSON output to JUnit XML |
+
+## Environment Variables
+
+When using `setup-server.sh`, all variables are auto-discovered from the running OGX instance.
+
+| Variable | Required | Description |
+|---|---|---|
+| `BASE_URL` | yes | OGX server URL (default: `http://localhost:8321`) |
+| `INFERENCE_MODEL` | yes | Inference model name (e.g. `vllm-inference/llama-3-2-3b`) |
+| `EMBEDDING_MODEL` | no | Embedding model name (skipped if unset) |
+| `EMBEDDING_DIMENSION` | no | Embedding vector dimension (default: `768`) |
+| `FILES_PROVIDER` | no | Files provider (skipped if unset) |
+| `INFERENCE_PROVIDER` | no | Inference provider (skipped if unset) |
+| `VECTOR_IO_PROVIDER` | no | Vector IO provider (skipped if unset) |
+| `HEALTH_CHECK_TIMEOUT` | no | Seconds to wait for server readiness (default: `0`) |
+
+## Test Layers
+
+This directory is one of three test layers in `tests/`:
+
+| Layer | Location | What it tests | Framework |
+|---|---|---|---|
+| Smoke | `tests/smoke.sh` | Health, models, basic inference, DB tables | Bash + curl |
+| Integration | `tests/run_integration_tests.sh` | Upstream OGX pytest suite | pytest (cloned from upstream) |
+| **Functional** | **`tests/functional/`** | API contracts, feature scenarios, provider coverage | Bruno + Jupyter + pytest |
+
+## Structure
+
+```
+functional/
+├── bruno/                        # Bruno API tests (see bruno/README.md)
+│   ├── ogx-api/                  # API test collections (numbered folders)
+│   └── environments/             # Shared env config
+├── notebooks/                    # Jupyter notebooks executed as pytest tests
+├── tests/
+│   └── test_notebooks.py         # pytest runner — executes notebooks as tests
+├── scripts/                      # Test orchestration and helpers
+└── pyproject.toml
+```
+
+## Konflux ITS
+
+The Tekton pipeline deploys OGX + PostgreSQL + vLLM as sidecars, clones this repo, and runs `run-tests-with-providers.sh`. No separate test image — tests run directly from source. See `odh-konflux-central/integration-tests/ogx-core/pr-its-pipeline.yaml`.
+
+## Writing Tests
+
+### Bruno (API contracts)
+
+Copy an existing `.bru` file, edit the request and assertions. Tests are auto-discovered by the runner. See `bruno/README.md`.
+
+### Notebooks (feature scenarios)
+
+Create `notebooks/test_<feature>.ipynb`. Use `ogx-client` for API calls and `assert` for validation. Auto-discovered by `tests/test_notebooks.py` — no registration needed.

--- a/tests/functional/bruno/README.md
+++ b/tests/functional/bruno/README.md
@@ -1,0 +1,56 @@
+# Bruno API Tests
+
+CRUD tests for OGX APIs. Each numbered folder under `ogx-api/` covers an API group. Tests are auto-discovered — add a `.bru` file and the runner picks it up.
+
+## Running locally
+
+### Via test runner (recommended)
+
+The test runner script starts a full local environment (OGX + PostgreSQL + vLLM) and runs all tests:
+
+```bash
+cd tests/functional
+./scripts/setup-server.sh --its              # full: start infra, run tests, cleanup
+./scripts/setup-server.sh --its --start-only # start infra only, print connection info
+./scripts/setup-server.sh --its --tests-only # run tests against already-running server
+./scripts/setup-server.sh --its --cleanup    # stop and remove containers
+```
+
+### Bruno CLI (standalone)
+
+```bash
+cd tests/functional/bruno
+npm ci
+# Uses defaults from ogx-api/environments/ogx.bru
+npx @usebruno/cli run ogx-api --env ogx
+# Override specific vars as needed:
+#   --env-var "baseUrl=http://my-server:8321" --env-var "model=my-model"
+```
+
+### Bruno App (GUI)
+
+1. Install [Bruno](https://www.usebruno.com/downloads) or the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=bruno-api-client.bruno)
+2. Open collection: **File → Open Collection → `bruno/ogx-api/`**
+3. Select environment: top-right dropdown → **ogx**
+4. Edit environment variables (`base_url`, `model`, provider labels)
+5. Run: right-click a folder → **Run**
+
+## Environment setup
+
+The environment file lives at `ogx-api/environments/ogx.bru`. Variables are placeholders — override them in the Bruno GUI or via `--env-var` on the CLI.
+
+Do not add comments to `.bru` env files — Bruno's parser does not support them.
+
+## Konflux ITS
+
+In Konflux, the Tekton pipeline clones this repo and runs `scripts/run-tests-with-providers.sh` directly — Bruno is installed via `npm ci` in the test step. No separate test image needed.
+
+## Writing tests
+
+- Every `.bru` file **must** contain at least one assertion — either a `tests {}` block or a `script:post-response` block with `expect()` calls. Files without assertions are caught by `scripts/lint_bruno.py`.
+- All env vars (`model`, `embedding_model`, `inference_provider`, `files_provider`, `vector_io_provider`) are **required**. Do not skip assertions with `if (!var) { return; }` — assert the var is set, then assert the value.
+- Use `tests {}` for declarative assertions. Use `script:post-response` when you need to chain variables with `bru.setEnvVar()`.
+
+## Provider overrides
+
+Set `VECTOR_IO_PROVIDER`, `INFERENCE_PROVIDER`, `FILES_PROVIDER` to test different backends with the same CRUD tests.

--- a/tests/functional/bruno/ogx-api/01-admin/List Models.bru
+++ b/tests/functional/bruno/ogx-api/01-admin/List Models.bru
@@ -1,0 +1,38 @@
+meta {
+  name: List Models
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/v1/models
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+
+  test("Response has models array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+    expect(body.data.length).to.be.greaterThan(0);
+  });
+
+  test("Inference model is registered", function() {
+    const model = bru.getEnvVar("model");
+    expect(model).to.be.a("string").and.not.empty;
+    const ids = res.getBody().data.map(m => m.id);
+    expect(ids).to.include(model);
+  });
+
+  test("Embedding model is registered", function() {
+    const model = bru.getEnvVar("embedding_model");
+    expect(model).to.be.a("string").and.not.empty;
+    const ids = res.getBody().data.map(m => m.id);
+    expect(ids).to.include(model);
+  });
+}

--- a/tests/functional/bruno/ogx-api/01-admin/List Providers.bru
+++ b/tests/functional/bruno/ogx-api/01-admin/List Providers.bru
@@ -1,0 +1,59 @@
+meta {
+  name: List Providers
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1alpha/admin/providers
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+
+  test("Response has providers array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+    expect(body.data.length).to.be.greaterThan(0);
+  });
+
+  test("Configured inference provider is registered", function() {
+    const provider = bru.getEnvVar("inference_provider");
+    expect(provider).to.be.a("string").and.not.empty;
+    const ids = res.getBody().data
+      .filter(p => p.api === "inference")
+      .map(p => p.provider_id);
+    expect(ids).to.include(provider);
+  });
+
+  test("Configured vector_io provider is registered", function() {
+    const provider = bru.getEnvVar("vector_io_provider");
+    expect(provider).to.be.a("string").and.not.empty;
+    const ids = res.getBody().data
+      .filter(p => p.api === "vector_io")
+      .map(p => p.provider_id);
+    expect(ids).to.include(provider);
+  });
+
+  test("Configured files provider is registered", function() {
+    const provider = bru.getEnvVar("files_provider");
+    expect(provider).to.be.a("string").and.not.empty;
+    const ids = res.getBody().data
+      .filter(p => p.api === "files")
+      .map(p => p.provider_id);
+    expect(ids).to.include(provider);
+  });
+
+  test("All providers have required fields", function() {
+    res.getBody().data.forEach(p => {
+      expect(p).to.have.property("api");
+      expect(p).to.have.property("provider_id");
+      expect(p).to.have.property("provider_type");
+    });
+  });
+}

--- a/tests/functional/bruno/ogx-api/bruno.json
+++ b/tests/functional/bruno/ogx-api/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "OGX API",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/tests/functional/bruno/ogx-api/collection.bru
+++ b/tests/functional/bruno/ogx-api/collection.bru
@@ -1,0 +1,7 @@
+meta {
+  name: OGX API
+}
+
+auth {
+  mode: none
+}

--- a/tests/functional/bruno/ogx-api/environments/ogx.bru
+++ b/tests/functional/bruno/ogx-api/environments/ogx.bru
@@ -1,0 +1,9 @@
+vars {
+  baseUrl: http://localhost:8321
+  model: vllm-inference/llama-3-2-3b
+  embedding_model: vllm-embedding/nomic-embed-text-v1-5
+  embedding_dimension: 768
+  inference_provider: vllm-inference
+  files_provider: meta-reference-files
+  vector_io_provider: pgvector
+}

--- a/tests/functional/bruno/package.json
+++ b/tests/functional/bruno/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "@usebruno/cli": "^3.2.1"
+  },
+  "scripts": {
+    "bruno:run": "cd ogx-api && bru run . -r"
+  }
+}

--- a/tests/functional/notebooks/README.md
+++ b/tests/functional/notebooks/README.md
@@ -1,0 +1,71 @@
+# Notebook Tests
+
+Jupyter notebooks executed as pytest test cases via `nbconvert.ExecutePreprocessor`. Each notebook runs to completion — any unhandled exception or failed `assert` fails the test. Notebooks are auto-discovered: add a `test_*.ipynb` file and the runner picks it up.
+
+## Running locally
+
+### Via test runner (recommended)
+
+```bash
+cd tests/functional
+./scripts/setup-server.sh --its              # full: start infra, run tests, cleanup
+./scripts/setup-server.sh --its --tests-only # run tests against already-running server
+```
+
+### Pytest (standalone)
+
+Export the required env vars, then run:
+
+```bash
+cd tests/functional
+export BASE_URL="http://localhost:8321"
+export INFERENCE_MODEL="vllm-inference/llama-3-2-3b"
+uv run pytest tests/test_notebooks.py -v
+# Run a single notebook:
+#   uv run pytest tests/test_notebooks.py -v -k "test_basic_inference"
+```
+
+## Environment variables
+
+Notebooks read env vars directly via `os.environ.get`. The test runner script (`run-tests-with-providers.sh`) exports them automatically.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `BASE_URL` | yes | OGX server URL (default: `http://localhost:8321`) |
+| `INFERENCE_MODEL` | yes | Inference model name |
+| `EMBEDDING_MODEL` | no | Embedding model name (skipped if unset) |
+| `EMBEDDING_DIMENSION` | no | Embedding vector dimension (default: `768`) |
+| `INFERENCE_PROVIDER` | no | Inference provider label (skipped if unset) |
+| `FILES_PROVIDER` | no | Files provider label (skipped if unset) |
+| `VECTOR_IO_PROVIDER` | no | Vector IO provider label (skipped if unset) |
+
+## Writing a new notebook
+
+1. Copy an existing notebook:
+
+   ```bash
+   cp notebooks/test_basic_inference.ipynb notebooks/test_<feature>.ipynb
+   ```
+
+2. Read env vars and import helpers in the first code cell:
+
+   ```python
+   import os
+   from ogx_client import OgxClient
+   from scripts.helpers import response_text
+
+   base_url = os.environ.get("BASE_URL", "http://localhost:8321")
+   model = os.environ.get("INFERENCE_MODEL", "")
+   assert model, "INFERENCE_MODEL must be set"
+   ```
+
+3. Follow this cell structure:
+   - **Cell 1** — imports + env var reads + assertions on required vars
+   - **Cell 2+** — test scenarios with `assert` statements
+   - **Last cell** — cleanup (delete created resources)
+
+4. Assert structure, not content — LLM output is non-deterministic. Check field existence, types, status codes.
+
+5. Every notebook must have at least one `assert` — enforced by `test_notebooks.py`.
+
+6. No registration needed — `tests/test_notebooks.py` auto-discovers all `*.ipynb` files in this directory.

--- a/tests/functional/notebooks/test_basic_inference.ipynb
+++ b/tests/functional/notebooks/test_basic_inference.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scenario 01: Basic Inference, Embedding, and Provider Health Check\n",
+    "\n",
+    "Validates that all configured env vars correspond to live, working endpoints:\n",
+    "\n",
+    "- **Inference:** temperature=0.0 determinism, temperature=1.0 variation, sampling params accepted.\n",
+    "- **Embedding:** model returns vectors with expected dimension.\n",
+    "- **Providers:** inference, files, and vector_io providers are registered on the server."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Setup\n\nLoad configuration from environment variables. Set via the test runner script or export manually."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport requests\nfrom ogx_client import OgxClient\nfrom scripts.helpers import response_text\n\nbase_url = os.environ.get(\"BASE_URL\", \"http://localhost:8321\")\nmodel = os.environ.get(\"INFERENCE_MODEL\", \"\")\nembedding_model = os.environ.get(\"EMBEDDING_MODEL\", \"\")\nembedding_dimension = int(os.environ.get(\"EMBEDDING_DIMENSION\", \"768\"))\ninference_provider = os.environ.get(\"INFERENCE_PROVIDER\", \"\")\nfiles_provider = os.environ.get(\"FILES_PROVIDER\", \"\")\nvector_io_provider = os.environ.get(\"VECTOR_IO_PROVIDER\", \"\")\n\nassert base_url, \"BASE_URL must be set\"\nassert model, \"INFERENCE_MODEL must be set\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deterministic behavior (temperature=0.0)\n",
+    "\n",
+    "With temperature 0, the model should return the same output for the same prompt when called twice.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "client = OgxClient(base_url=base_url)\n\nprompt = \"Reply with exactly one number: 42.\"\nr1 = client.responses.create(model=model, input=prompt, temperature=0.0)\nr2 = client.responses.create(model=model, input=prompt, temperature=0.0)\n\nassert r1.status == \"completed\", f\"Expected status completed, got {r1.status}\"\nassert r2.status == \"completed\", f\"Expected status completed, got {r2.status}\"\ntext1 = response_text(r1)\ntext2 = response_text(r2)\nassert text1 and text2, \"Expected non-empty response text\"\nassert text1.strip() == text2.strip(), (\n    f\"Determinism failed: temp=0.0 should give identical outputs. Got: {text1!r} vs {text2!r}\"\n)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Non-deterministic behavior (temperature=1.0)\n",
+    "\n",
+    "With temperature 1.0, we only verify that the API completes and returns valid output; we do not require identical responses across runs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "r = client.responses.create(\n    model=model,\n    input=\"Name one European capital city.\",\n    temperature=1.0,\n)\nassert r.status == \"completed\", f\"Expected status completed, got {r.status}\"\ntext = response_text(r)\nassert text, \"Expected non-empty response for temperature=1.0\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sampling parameter (temperature only)\n",
+    "\n",
+    "Verify that temperature is accepted and a completed response is returned. Note: `top_p` is not supported in the Responses API `responses.create`; use the Chat Completions API for `top_p`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "r = client.responses.create(\n    model=model,\n    input=\"Say hello in one word.\",\n    temperature=0.3,\n)\nassert r.status == \"completed\", f\"Expected status completed, got {r.status}\"\nassert r.output is not None, \"Expected output to be present\""
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embedding model health check\n",
+    "\n",
+    "Verify the embedding model is reachable and returns vectors with the expected dimension. Uses the OpenAI-compatible `/v1/embeddings` endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if not embedding_model:\n    print(\"EMBEDDING_MODEL not set — skipping embedding test\")\nelse:\n    resp = requests.post(\n        f\"{base_url}/v1/embeddings\",\n        json={\"model\": embedding_model, \"input\": \"health check\"},\n    )\n    assert resp.status_code == 200, (\n        f\"Embeddings endpoint returned {resp.status_code}: {resp.text}\"\n    )\n\n    data = resp.json()\n    assert \"data\" in data, f\"Expected 'data' key in response: {data}\"\n    assert len(data[\"data\"]) > 0, \"Expected at least one embedding\"\n\n    vector = data[\"data\"][0][\"embedding\"]\n    assert len(vector) == embedding_dimension, (\n        f\"Expected dimension {embedding_dimension}, got {len(vector)}\"\n    )"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Provider health check\n",
+    "\n",
+    "Verify that all configured providers (inference, files, vector_io) are registered on the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "if not all([inference_provider, files_provider, vector_io_provider]):\n    print(\"Provider vars not fully set — skipping provider check\")\nelse:\n    resp = requests.get(f\"{base_url}/v1/providers\")\n    assert resp.status_code == 200, (\n        f\"Providers endpoint returned {resp.status_code}: {resp.text}\"\n    )\n\n    providers = resp.json().get(\"data\", [])\n    provider_map = {}\n    for p in providers:\n        provider_map.setdefault(p[\"api\"], []).append(p[\"provider_id\"])\n\n    for api, expected in [\n        (\"inference\", inference_provider),\n        (\"files\", files_provider),\n        (\"vector_io\", vector_io_provider),\n    ]:\n        registered = provider_map.get(api, [])\n        assert expected in registered, (\n            f\"{api} provider '{expected}' not registered. Available: {registered}\"\n        )"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## QE Assertions summary\n",
+    "\n",
+    "- Deterministic (temp=0.0): two identical prompts yield identical response text.\n",
+    "- Non-deterministic (temp=1.0): response completes with non-empty output.\n",
+    "- Temperature parameter: request completes successfully with output present.\n",
+    "- Embedding: model returns vectors with expected dimension.\n",
+    "- Providers: inference, files, and vector_io providers are registered on the server."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "OGX Functional Tests (.venv)",
+   "language": "python",
+   "name": "ogx-functional"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/functional/pyproject.toml
+++ b/tests/functional/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "ogx-functional-tests"
+version = "0.1.0"
+description = "Functional tests for OGX (Bruno + notebooks)"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "ogx-client~=1.0.0",
+    "openai>=2.24.0",
+    "pytest>=9.0.2",
+    "nbformat>=5.10.4",
+    "nbconvert>=7.17.0",
+    "ipykernel>=7.2.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scripts"]
+
+[tool.ruff]
+extend-exclude = ["bruno/"]
+
+[tool.ruff.lint.per-file-ignores]
+"notebooks/*.ipynb" = ["E402"]

--- a/tests/functional/scripts/bruno_summary.py
+++ b/tests/functional/scripts/bruno_summary.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Parse Bruno CLI JSON output, print summary, optionally write JUnit XML.
+
+Bruno CLI v3 counts only declarative `tests {}` / `assert {}` blocks in its
+summary table.  Tests written in `script:post-response` (which is what we use)
+land in `postResponseTestResults` and are silently ignored by the counter.
+
+Usage:
+  bruno-summary.py <results.json> [junit-output.xml]
+
+Exit code: 0 if all pass, 1 if any fail.
+"""
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def write_junit_xml(iterations, xml_path):
+    """Write JUnit XML from parsed Bruno results."""
+    testsuites = ET.Element("testsuites")
+    suite = ET.SubElement(testsuites, "testsuite", name="bruno-crud")
+
+    total_tests = total_failures = total_errors = 0
+
+    for iteration in iterations:
+        for result in iteration.get("results", []):
+            name = result.get("path") or result.get("name", "unknown")
+            resp = result.get("response", {})
+            runtime = f"{resp.get('responseTime', 0) / 1000:.3f}"
+
+            for bucket in (
+                "postResponseTestResults",
+                "testResults",
+                "preRequestTestResults",
+            ):
+                for t in result.get(bucket, []):
+                    total_tests += 1
+                    desc = t.get("description", "unnamed assertion")
+                    tc = ET.SubElement(
+                        suite, "testcase", name=desc, classname=name, time=runtime
+                    )
+                    if t.get("status") != "pass":
+                        total_failures += 1
+                        fail = ET.SubElement(
+                            tc, "failure", message=desc, type="AssertionError"
+                        )
+                        fail.text = t.get("error", desc)
+
+            if result.get("error"):
+                total_tests += 1
+                total_errors += 1
+                tc = ET.SubElement(
+                    suite,
+                    "testcase",
+                    name=f"{name} (request error)",
+                    classname=name,
+                    time=runtime,
+                )
+                err = ET.SubElement(
+                    tc, "error", message=str(result["error"]), type="RequestError"
+                )
+                err.text = str(result["error"])
+
+    suite.set("tests", str(total_tests))
+    suite.set("failures", str(total_failures))
+    suite.set("errors", str(total_errors))
+
+    Path(xml_path).parent.mkdir(parents=True, exist_ok=True)
+    tree = ET.ElementTree(testsuites)
+    ET.indent(tree, space="  ")
+    tree.write(xml_path, xml_declaration=True, encoding="unicode")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: bruno-summary.py <results.json> [junit.xml]", file=sys.stderr)
+        sys.exit(2)
+
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+
+    iterations = data if isinstance(data, list) else [data]
+
+    requests_pass = requests_fail = 0
+    tests_pass = tests_fail = 0
+    failures = []
+
+    for iteration in iterations:
+        for result in iteration.get("results", []):
+            name = result.get("path") or result.get("name", "?")
+            status = result.get("status", "unknown")
+
+            if status == "pass":
+                requests_pass += 1
+            else:
+                requests_fail += 1
+
+            for bucket in (
+                "postResponseTestResults",
+                "testResults",
+                "preRequestTestResults",
+            ):
+                for t in result.get(bucket, []):
+                    if t.get("status") == "pass":
+                        tests_pass += 1
+                    else:
+                        tests_fail += 1
+                        failures.append(f"  FAIL  {name}: {t.get('description', '?')}")
+
+            if result.get("error"):
+                failures.append(f"  ERR   {name}: {result['error']}")
+
+    total_requests = requests_pass + requests_fail
+    total_tests = tests_pass + tests_fail
+    ok = requests_fail == 0 and tests_fail == 0
+
+    # Write JUnit XML if output path provided
+    xml_path = sys.argv[2] if len(sys.argv) > 2 else None
+    if xml_path:
+        write_junit_xml(iterations, xml_path)
+        print(f"  JUnit XML:  {xml_path}")
+
+    print()
+    print(f"  Requests:   {requests_pass}/{total_requests} passed")
+    print(f"  Assertions: {tests_pass}/{total_tests} passed")
+    print(f"  Status:     {'PASS' if ok else 'FAIL'}")
+
+    if failures:
+        print()
+        for line in failures:
+            print(line)
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/scripts/helpers.py
+++ b/tests/functional/scripts/helpers.py
@@ -1,0 +1,15 @@
+"""Shared helpers for notebook and script tests."""
+
+
+def response_text(r):
+    """Extract full text from a Responses API response object."""
+    t = getattr(r, "output_text", None)
+    if t:
+        return t
+    if getattr(r, "output", None):
+        for i in range(len(r.output) - 1, -1, -1):
+            if getattr(r.output[i], "content", None):
+                c = r.output[i].content[0]
+                if getattr(c, "text", None):
+                    return c.text
+    return str(r.output) if getattr(r, "output", None) else ""

--- a/tests/functional/scripts/lint_bruno.py
+++ b/tests/functional/scripts/lint_bruno.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Lint Bruno .bru files: verify each request file has at least one assertion block."""
+
+import sys
+from pathlib import Path
+
+BRUNO_DIR = Path(__file__).resolve().parent.parent / "bruno" / "ogx-api"
+SKIP = {"collection.bru"}
+ASSERTION_MARKERS = ("tests {", "script:post-response")
+
+
+def main():
+    failures = []
+    bru_files = sorted(BRUNO_DIR.rglob("*.bru"))
+    bru_files = [
+        f for f in bru_files if f.name not in SKIP and "environments" not in f.parts
+    ]
+
+    for path in bru_files:
+        content = path.read_text()
+        if not any(marker in content for marker in ASSERTION_MARKERS):
+            failures.append(path.relative_to(BRUNO_DIR))
+
+    if failures:
+        print(f"Bruno files without assertions ({len(failures)}):")
+        for f in failures:
+            print(f"  {f}")
+        sys.exit(1)
+
+    print(f"All {len(bru_files)} Bruno request files have assertions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/scripts/run-tests-with-providers.sh
+++ b/tests/functional/scripts/run-tests-with-providers.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+# Run Bruno CRUD and notebook tests for a given provider combination.
+# Requires: BASE_URL, INFERENCE_MODEL, EMBEDDING_MODEL,
+#           INFERENCE_PROVIDER, FILES_PROVIDER, VECTOR_IO_PROVIDER.
+#
+# Example:
+#   export BASE_URL="http://localhost:8321"
+#   export INFERENCE_MODEL="vllm-inference/llama-3-2-3b"
+#   ./scripts/run-tests-with-providers.sh
+
+set -euo pipefail
+
+# Prevent Bruno's shell-env from spawning interactive login shells (hangs when .bashrc execs fish)
+export SHELL=/bin/bash
+export BRUNO_SKIP_SHELL_ENV=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BRUNO_DIR="${REPO_ROOT}/bruno"
+NOTEBOOKS_DIR="${REPO_ROOT}/notebooks"
+REPORTS_DIR="${REPO_ROOT}/reports"
+EXIT_CODE=0
+
+mkdir -p "${REPORTS_DIR}"
+
+if [[ -z "${BASE_URL:-}" ]]; then
+  echo "Error: BASE_URL is required (e.g. http://localhost:8321)" >&2
+  exit 1
+fi
+if [[ -z "${INFERENCE_MODEL:-}" ]]; then
+  echo "Error: INFERENCE_MODEL is required for inference tests (e.g. vllm-inference/llama-3-2-3b)" >&2
+  exit 1
+fi
+
+export FILES_PROVIDER="${FILES_PROVIDER:-}"
+export INFERENCE_PROVIDER="${INFERENCE_PROVIDER:-}"
+export VECTOR_IO_PROVIDER="${VECTOR_IO_PROVIDER:-}"
+export EMBEDDING_MODEL="${EMBEDDING_MODEL:-}"
+
+# Wait for server to become healthy (opt-in via HEALTH_CHECK_TIMEOUT).
+# Skipped when timeout is 0 or unset (local dev). Set to e.g. 600 in CI/Tekton.
+_wait_for_server() {
+  local timeout="${HEALTH_CHECK_TIMEOUT:-0}"
+  if [[ "$timeout" -le 0 ]]; then
+    return 0
+  fi
+  local url="${BASE_URL}/v1/health"
+  local interval=2
+  local max_interval=15
+  local elapsed=0
+  echo "Waiting for server at ${url} (timeout: ${timeout}s)..."
+  while [[ "$elapsed" -lt "$timeout" ]]; do
+    if curl -sf --connect-timeout 3 "${url}" >/dev/null 2>&1; then
+      echo "  Server ready after ${elapsed}s"
+      return 0
+    fi
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+    if [[ "$interval" -lt "$max_interval" ]]; then
+      interval=$((interval * 2 > max_interval ? max_interval : interval * 2))
+    fi
+  done
+  echo "Error: server at ${url} not ready after ${timeout}s — sidecar may have crashed" >&2
+  return 1
+}
+
+_wait_for_server
+
+source "$(dirname "${BASH_SOURCE[0]}")/sync-client-version.sh"
+
+# Health-check helper: verify the server is reachable, restart port-forward if needed
+_ensure_server() {
+  if curl -sf --connect-timeout 3 "${BASE_URL}/v1/health" >/dev/null 2>&1; then
+    return 0
+  fi
+  local ns="${OC_NAMESPACE-}"
+  if [[ -z "$ns" ]]; then
+    echo "  Server unreachable at ${BASE_URL} (port-forward disabled)" >&2
+    return 1
+  fi
+  echo "  Server unreachable at ${BASE_URL} — attempting port-forward restart..."
+  pkill -f "port-forward.*${ns}" 2>/dev/null || true
+  sleep 1
+  local svc="${OC_SERVICE:-svc/ogx-vllm-vertex-service}"
+  local port="${BASE_URL##*:}"  # extract port from http://host:PORT
+  oc port-forward -n "${ns}" "${svc}" "${port}:${port}" >/dev/null 2>&1 &
+  sleep 4
+  if curl -sf --connect-timeout 3 "${BASE_URL}/v1/health" >/dev/null 2>&1; then
+    echo "  Port-forward restored"
+    return 0
+  fi
+  echo "  Warning: could not restore connectivity to ${BASE_URL}" >&2
+  return 1
+}
+
+echo ""
+echo "=== Provider matrix test run ==="
+echo "  BASE_URL           = ${BASE_URL}"
+echo "  INFERENCE_MODEL    = ${INFERENCE_MODEL}"
+echo "  EMBEDDING_MODEL    = ${EMBEDDING_MODEL}"
+echo "  INFERENCE_PROVIDER = ${INFERENCE_PROVIDER}"
+echo "  FILES_PROVIDER     = ${FILES_PROVIDER}"
+echo "  VECTOR_IO_PROVIDER = ${VECTOR_IO_PROVIDER}"
+echo ""
+
+# ── Bruno CLI ────────────────────────────────────────────────────────────────
+BRU=""
+if [[ -x "${BRUNO_DIR}/node_modules/.bin/bru" ]]; then
+  BRU="${BRUNO_DIR}/node_modules/.bin/bru"
+elif command -v bru &>/dev/null; then
+  BRU="bru"
+elif command -v npm &>/dev/null && [[ -f "${BRUNO_DIR}/package.json" ]]; then
+  echo "Installing Bruno CLI via npm ci..."
+  (cd "${BRUNO_DIR}" && npm ci --ignore-scripts 2>&1) || echo "  Warning: npm ci failed"
+  if [[ -x "${BRUNO_DIR}/node_modules/.bin/bru" ]]; then
+    BRU="${BRUNO_DIR}/node_modules/.bin/bru"
+  fi
+fi
+
+_env_vars=(
+  --env-var "baseUrl=${BASE_URL}"
+  --env-var "model=${INFERENCE_MODEL}"
+  --env-var "embedding_model=${EMBEDDING_MODEL}"
+  --env-var "embedding_dimension=${EMBEDDING_DIMENSION:-768}"
+  --env-var "inference_provider=${INFERENCE_PROVIDER}"
+  --env-var "files_provider=${FILES_PROVIDER}"
+  --env-var "vector_io_provider=${VECTOR_IO_PROVIDER}"
+)
+
+# ── Phase 1: Bruno CRUD tests (fail-fast) ───────────────────────────────────
+OGX_CRUD_DIR="${BRUNO_DIR}/ogx-api"
+if [[ -n "${BRU}" && -d "${OGX_CRUD_DIR}" ]]; then
+  _ensure_server
+  echo ">>> Phase 1: Bruno CRUD tests"
+  _bruno_json=$(mktemp /tmp/bruno-results-XXXXXX.json)
+  _bruno_log=$(mktemp /tmp/bruno-log-XXXXXX.txt)
+  _bruno_exit=0
+  BRUNO_TIMEOUT="${BRUNO_TIMEOUT:-600}"
+  # shellcheck disable=SC2086
+  # setsid detaches Bruno from the controlling terminal — its shell-env plugin opens
+  # /dev/tty directly and hangs when the session leader is a non-bash shell (e.g. fish)
+  (cd "${OGX_CRUD_DIR}" && setsid timeout "${BRUNO_TIMEOUT}" $BRU run . -r "${_env_vars[@]}" --output "${_bruno_json}") \
+    < /dev/null > "${_bruno_log}" 2>&1 || _bruno_exit=$?
+  if [[ $_bruno_exit -eq 124 ]]; then
+    echo "  Bruno CRUD tests timed out after ${BRUNO_TIMEOUT}s"
+  fi
+  # Display filtered output (strip proxy warnings and misleading built-in summary)
+  grep -v -e "proxy" -e "Proxy" -e "getSystem" -e "at async" -e "at .*/node_modules/" -e "^$" < "${_bruno_log}" \
+    | sed '/📊 Execution Summary/,/└.*┘/d' || true
+  rm -f "${_bruno_log}"
+  # Evaluate results: JSON output is authoritative, exit code catches crashes
+  if [[ -s "${_bruno_json}" ]]; then
+    if ! python3 "${REPO_ROOT}/scripts/bruno_summary.py" "${_bruno_json}" "${REPORTS_DIR}/bruno-crud.xml"; then
+      EXIT_CODE=1
+    fi
+  elif [[ $_bruno_exit -ne 0 ]]; then
+    echo "  Error: Bruno CLI crashed (exit code ${_bruno_exit}) with no test output"
+    EXIT_CODE=1
+  else
+    echo "  Warning: no Bruno JSON output produced"
+    EXIT_CODE=1
+  fi
+  rm -f "${_bruno_json}"
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "  CRUD tests failed — skipping notebooks (fail-fast)"
+    exit "$EXIT_CODE"
+  fi
+  echo ""
+else
+  echo ">>> Phase 1: skipped (Bruno CLI not found)"
+fi
+
+# ── Phase 2: Notebooks ──────────────────────────────────────────────────────
+if [[ -d "$NOTEBOOKS_DIR" ]]; then
+  if ! curl -sf --connect-timeout 3 "${BASE_URL}/v1/health" >/dev/null 2>&1; then
+    echo "Error: server at ${BASE_URL} is down after Phase 1 — skipping notebooks" >&2
+    echo "  The server may have crashed (OOM, sidecar exit). Check sidecar logs." >&2
+    exit 1
+  fi
+  echo ">>> Phase 2: Notebooks — pytest"
+  export BASE_URL INFERENCE_MODEL FILES_PROVIDER INFERENCE_PROVIDER VECTOR_IO_PROVIDER EMBEDDING_MODEL
+  export MODEL="${INFERENCE_MODEL}"
+  export PYTHONPATH="${REPO_ROOT}:${PYTHONPATH:-}"
+  if ! (cd "$REPO_ROOT" && uv run pytest tests/test_notebooks.py -v --tb=short --junitxml="${REPORTS_DIR}/notebooks.xml"); then
+    EXIT_CODE=1
+  fi
+  echo ""
+fi
+
+exit $EXIT_CODE

--- a/tests/functional/scripts/setup-server.sh
+++ b/tests/functional/scripts/setup-server.sh
@@ -1,0 +1,695 @@
+#!/usr/bin/env bash
+#
+# Start PostgreSQL + OGX containers, auto-discover the model, run tests.
+#
+# Usage:
+#   ./scripts/setup-server.sh              # Full: start infra, run tests, cleanup
+#   ./scripts/setup-server.sh --start-only # Start infra, discover model, print info
+#   ./scripts/setup-server.sh --tests-only # Run tests against already-running server
+#   ./scripts/setup-server.sh --cleanup    # Stop and remove containers
+#   ./scripts/setup-server.sh --its        # Konflux ITS mode: podman pod + vLLM sidecars
+#
+# Options:
+#   --start-only     Start PostgreSQL + OGX, then exit
+#   --tests-only     Run tests against existing OGX server (uses BASE_URL or localhost:8321)
+#   --cleanup        Remove containers and exit
+#   --no-cleanup     In full mode, keep containers after tests
+#   --its            ITS mode: use podman pod (shared localhost) with vLLM inference
+#                    + embedding sidecars. Emulates the Konflux ITS Tekton pipeline.
+#   --image IMAGE    Override OGX container image
+#   --help           Show this help
+#
+# Infrastructure env vars (with defaults):
+#   OGX_IMAGE   Container image (default: quay.io/rhoai/odh-ogx-core-rhel9:rhoai-3.5-ea.2)
+#   OGX_PORT    Host port for OGX (default: 8321)
+#   POSTGRES_IMAGE      Postgres image (default: postgres:17-alpine)
+#   POSTGRES_USER       Postgres user (default: ogx)
+#   POSTGRES_PASSWORD   Postgres password (default: ogx)
+#   POSTGRES_DB         Postgres database (default: ogx)
+#   POSTGRES_PORT       Host port for Postgres (default: 5432)
+#   CLEANUP_DB          Clean DB on startup: true/false (default: false)
+# INFERENCE_MODEL       Inference model (default: auto-discovered from server)
+#
+# ITS mode env vars (defaults match pr-its-pipeline.yaml):
+#   VLLM_IMAGE          vLLM image (default: quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english)
+#   VLLM_INFERENCE_MODEL       Inference model name (default: Qwen/Qwen3-0.6B)
+#   VLLM_INFERENCE_MODEL_PATH  Model path in container (default: /root/.cache/Qwen/Qwen3-0.6B)
+#   VLLM_EMBEDDING_MODEL       Embedding model name (default: ibm-granite/granite-embedding-125m-english)
+#   VLLM_EMBEDDING_MODEL_PATH  Model path in container (default: /root/.cache/ibm-granite/granite-embedding-125m-english)
+#
+# Provider env vars (forwarded to OGX container if set):
+#   VLLM_URL, VLLM_API_TOKEN, VLLM_TLS_VERIFY
+#   VLLM_EMBEDDING_URL, VLLM_EMBEDDING_API_TOKEN, VLLM_EMBEDDING_TLS_VERIFY
+#   INFERENCE_MODEL, EMBEDDING_MODEL, EMBEDDING_PROVIDER, EMBEDDING_PROVIDER_MODEL_ID
+#   GOOGLE_CLOUD_PROJECT, VERTEX_AI_PROJECT, VERTEX_AI_LOCATION, GOOGLE_APPLICATION_CREDENTIALS
+#   AWS_BEARER_TOKEN_BEDROCK, AWS_DEFAULT_REGION
+#   ENABLE_KUBEFLOW_GARAK, ENABLE_SENTENCE_TRANSFORMERS, OGX_LOGGING
+#
+
+set -euo pipefail
+
+# Force SHELL=bash to prevent Bruno's shell-env from spawning fish (hangs on bash -ilc syntax)
+export SHELL=/bin/bash
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+OGX_IMAGE="${OGX_IMAGE:-quay.io/rhoai/odh-ogx-core-rhel9:rhoai-3.5-ea.2}"
+OGX_PORT="${OGX_PORT:-8321}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-docker.io/pgvector/pgvector:pg17}"
+POSTGRES_USER="${POSTGRES_USER:-ogx}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-ogx}"
+POSTGRES_DB="${POSTGRES_DB:-ogx}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+CLEANUP_DB="${CLEANUP_DB:-false}"
+
+CONTAINER_NAME_PG="postgres-local"
+CONTAINER_NAME_OGX="ogx-local"
+NETWORK_NAME="ogx-network"
+VOLUME_NAME="postgres-data"
+
+# ITS mode config (matches pr-its-pipeline.yaml)
+ITS_MODE=false
+POD_NAME="ogx-its-pod"
+VLLM_IMAGE="${VLLM_IMAGE:-quay.io/opendatahub/vllm-cpu:Qwen3-0.6B-granite-embedding-125m-english}"
+VLLM_INFERENCE_MODEL="${VLLM_INFERENCE_MODEL:-Qwen/Qwen3-0.6B}"
+VLLM_INFERENCE_MODEL_PATH="${VLLM_INFERENCE_MODEL_PATH:-/root/.cache/Qwen/Qwen3-0.6B}"
+VLLM_EMBEDDING_MODEL="${VLLM_EMBEDDING_MODEL:-ibm-granite/granite-embedding-125m-english}"
+VLLM_EMBEDDING_MODEL_PATH="${VLLM_EMBEDDING_MODEL_PATH:-/root/.cache/ibm-granite/granite-embedding-125m-english}"
+
+# Provider env vars forwarded to the OGX container (if set in calling env)
+FORWARD_VARS=(
+    INFERENCE_MODEL EMBEDDING_MODEL EMBEDDING_PROVIDER EMBEDDING_PROVIDER_MODEL_ID
+    VLLM_TLS_VERIFY VLLM_EMBEDDING_TLS_VERIFY
+    GOOGLE_CLOUD_PROJECT VERTEX_AI_PROJECT VERTEX_AI_LOCATION
+    AWS_BEARER_TOKEN_BEDROCK AWS_DEFAULT_REGION
+    OPENAI_API_KEY
+    ENABLE_PGVECTOR PGVECTOR_HOST PGVECTOR_PORT PGVECTOR_DB PGVECTOR_USER PGVECTOR_PASSWORD
+    ENABLE_KUBEFLOW_GARAK ENABLE_SENTENCE_TRANSFORMERS
+    OGX_LOGGING
+)
+
+# Sensitive vars to mask in printed commands
+SENSITIVE_KEYS_REGEX='^(POSTGRES_PASSWORD|PGVECTOR_PASSWORD|AWS_BEARER_TOKEN_BEDROCK|VLLM_API_TOKEN|VLLM_EMBEDDING_API_TOKEN|OPENAI_API_KEY)$'
+
+# ── Colors ────────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+
+MODE="full"
+DO_CLEANUP=true
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --start-only)  MODE="start-only"; shift ;;
+        --tests-only)  MODE="tests-only"; shift ;;
+        --cleanup)     MODE="cleanup"; shift ;;
+        --no-cleanup)  DO_CLEANUP=false; shift ;;
+        --its)         ITS_MODE=true; shift ;;
+        --image)       OGX_IMAGE="$2"; shift 2 ;;
+        --help|-h)
+            sed -n '2,/^$/{ s/^# \?//; p }' "$0"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Preflight checks ─────────────────────────────────────────────────────────
+
+check_prerequisites() {
+    local missing=()
+    command -v podman &>/dev/null || missing+=("podman")
+    command -v curl &>/dev/null   || missing+=("curl")
+    command -v python3 &>/dev/null || missing+=("python3")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo -e "${RED}Missing required tools: ${missing[*]}${NC}" >&2
+        exit 1
+    fi
+}
+
+# ── Functions ─────────────────────────────────────────────────────────────────
+
+ensure_network() {
+    if ! podman network exists "${NETWORK_NAME}" 2>/dev/null; then
+        echo "Creating podman network: ${NETWORK_NAME}"
+        podman network create "${NETWORK_NAME}"
+    fi
+}
+
+# ── ITS mode helpers ─────────────────────────────────────────────────────────
+
+wait_for_http() {
+    local desc="$1" url="$2" timeout="$3"
+    local interval=2 max_interval=15 elapsed=0
+
+    echo -e "${BLUE}Waiting for ${desc} (timeout: ${timeout}s)...${NC}"
+    while [[ "$elapsed" -lt "$timeout" ]]; do
+        if curl -4 -sf --connect-timeout 3 "$url" >/dev/null 2>&1; then
+            echo -e "${GREEN}  ${desc} ready (${elapsed}s)${NC}"
+            return 0
+        fi
+        if (( elapsed % 30 == 0 && elapsed > 0 )); then
+            echo -e "${YELLOW}  Still waiting for ${desc}... (${elapsed}s)${NC}"
+        fi
+        sleep "$interval"
+        elapsed=$((elapsed + interval))
+        interval=$((interval < max_interval ? interval * 2 : max_interval))
+    done
+    echo -e "${RED}  ${desc} not ready after ${timeout}s${NC}" >&2
+    return 1
+}
+
+create_pod() {
+    echo -e "${GREEN}Creating pod: ${POD_NAME}${NC}"
+    podman pod rm -f "$POD_NAME" 2>/dev/null || true
+    podman pod create \
+        --name "$POD_NAME" \
+        -p "${OGX_PORT}:8321" \
+        -p 8000:8000 \
+        -p 8001:8001
+}
+
+start_vllm_inference() {
+    echo -e "${GREEN}Starting vLLM inference (${VLLM_INFERENCE_MODEL})...${NC}"
+    podman run -d \
+        --pod "$POD_NAME" \
+        --name "${POD_NAME}-vllm-inference" \
+        "$VLLM_IMAGE" \
+        --host 0.0.0.0 \
+        --port 8000 \
+        --enable-auto-tool-choice \
+        --tool-call-parser hermes \
+        --model "$VLLM_INFERENCE_MODEL_PATH" \
+        --served-model-name "$VLLM_INFERENCE_MODEL" \
+        --max-model-len 8192 \
+        --gpu-memory-utilization 0.50
+
+    wait_for_http "vLLM inference" "http://localhost:8000/health" 600
+}
+
+start_vllm_embedding() {
+    echo -e "${GREEN}Starting vLLM embedding (${VLLM_EMBEDDING_MODEL})...${NC}"
+    podman run -d \
+        --pod "$POD_NAME" \
+        --name "${POD_NAME}-vllm-embedding" \
+        "$VLLM_IMAGE" \
+        --host 0.0.0.0 \
+        --port 8001 \
+        --model "$VLLM_EMBEDDING_MODEL_PATH" \
+        --served-model-name "$VLLM_EMBEDDING_MODEL" \
+        --gpu-memory-utilization 0.05 \
+        --hf-overrides '{"is_matryoshka": true}'
+
+    wait_for_http "vLLM embedding" "http://localhost:8001/health" 600
+}
+
+# ── Standard mode functions ──────────────────────────────────────────────────
+
+start_postgres() {
+    echo -e "${GREEN}Starting PostgreSQL...${NC}"
+
+    local pg_name pg_run_args=()
+    if [[ "$ITS_MODE" == true ]]; then
+        pg_name="${POD_NAME}-postgres"
+        pg_run_args=(--pod "$POD_NAME" --name "$pg_name")
+    else
+        pg_name="${CONTAINER_NAME_PG}"
+        podman rm -f "$pg_name" 2>/dev/null || true
+        if ! podman volume exists "${VOLUME_NAME}" 2>/dev/null; then
+            podman volume create "${VOLUME_NAME}"
+        fi
+        ensure_network
+        pg_run_args=(
+            --name "$pg_name"
+            --network "${NETWORK_NAME}"
+            -p "${POSTGRES_PORT}:5432"
+            -v "${VOLUME_NAME}:/var/lib/postgresql/data/pgdata"
+            -e "PGDATA=/var/lib/postgresql/data/pgdata"
+        )
+    fi
+
+    podman run -d \
+        "${pg_run_args[@]}" \
+        -e "POSTGRES_DB=${POSTGRES_DB}" \
+        -e "POSTGRES_USER=${POSTGRES_USER}" \
+        -e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+        "${POSTGRES_IMAGE}"
+
+    echo "Waiting for PostgreSQL..."
+    for i in {1..30}; do
+        if podman exec "$pg_name" pg_isready -U "${POSTGRES_USER}" >/dev/null 2>&1; then
+            echo -e "${GREEN}PostgreSQL is ready.${NC}"
+
+            if [[ "${CLEANUP_DB}" == "true" ]]; then
+                echo "Cleaning up database..."
+                if [[ "${POSTGRES_DB}" == "postgres" ]]; then
+                    podman exec "$pg_name" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+                        -c "DROP SCHEMA IF EXISTS public CASCADE;" 2>/dev/null || true
+                    podman exec "$pg_name" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+                        -c "CREATE SCHEMA public;" 2>/dev/null || true
+                    podman exec "$pg_name" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+                        -c "GRANT ALL ON SCHEMA public TO ${POSTGRES_USER};" 2>/dev/null || true
+                else
+                    podman exec "$pg_name" psql -U "${POSTGRES_USER}" -d postgres \
+                        -c "DROP DATABASE IF EXISTS ${POSTGRES_DB};" 2>/dev/null || true
+                    podman exec "$pg_name" psql -U "${POSTGRES_USER}" -d postgres \
+                        -c "CREATE DATABASE ${POSTGRES_DB};"
+                fi
+                echo -e "${GREEN}Database cleaned up.${NC}"
+            fi
+            return 0
+        fi
+        if [[ $i -eq 30 ]]; then
+            echo -e "${RED}PostgreSQL did not become ready within 30 seconds.${NC}" >&2
+            podman logs "$pg_name" 2>&1 | tail -20
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
+start_ogx() {
+    echo -e "${GREEN}Starting OGX...${NC}"
+    echo "Image: ${OGX_IMAGE}"
+
+    local postgres_host RUN_ARGS=()
+
+    if [[ "$ITS_MODE" == true ]]; then
+        postgres_host="localhost"
+        RUN_ARGS=(
+            --pod "$POD_NAME"
+            --name "${POD_NAME}-ogx"
+            -e "POSTGRES_HOST=${postgres_host}"
+            -e "POSTGRES_PORT=5432"
+            -e "POSTGRES_DB=${POSTGRES_DB}"
+            -e "POSTGRES_USER=${POSTGRES_USER}"
+            -e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
+            -e "ENABLE_PGVECTOR=1"
+            -e "PGVECTOR_HOST=${postgres_host}"
+            -e "PGVECTOR_PORT=5432"
+            -e "PGVECTOR_DB=${POSTGRES_DB}"
+            -e "PGVECTOR_USER=${POSTGRES_USER}"
+            -e "PGVECTOR_PASSWORD=${POSTGRES_PASSWORD}"
+            -e "VLLM_URL=http://localhost:8000/v1"
+            -e "VLLM_EMBEDDING_URL=http://localhost:8001/v1"
+            -e "EMBEDDING_MODEL=${VLLM_EMBEDDING_MODEL}"
+            -e "TRUSTYAI_LMEVAL_USE_K8S=False"
+        )
+    else
+        postgres_host="${CONTAINER_NAME_PG}"
+
+        if ! podman ps --format "{{.Names}}" | grep -q "^${CONTAINER_NAME_PG}$"; then
+            echo -e "${RED}PostgreSQL container '${CONTAINER_NAME_PG}' is not running.${NC}" >&2
+            exit 1
+        fi
+
+        podman rm -f "${CONTAINER_NAME_OGX}" 2>/dev/null || true
+        ensure_network
+
+        RUN_ARGS=(
+            --name "${CONTAINER_NAME_OGX}"
+            --network "${NETWORK_NAME}"
+            -p "${OGX_PORT}:8321"
+            -e "POSTGRES_HOST=${postgres_host}"
+            -e "POSTGRES_PORT=5432"
+            -e "POSTGRES_DB=${POSTGRES_DB}"
+            -e "POSTGRES_USER=${POSTGRES_USER}"
+            -e "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
+        )
+
+        # Forward VLLM_URL with /v1 suffix if needed
+        if [[ -n "${VLLM_URL:-}" ]]; then
+            local vllm_url="${VLLM_URL}"
+            [[ "${vllm_url}" != */v1 ]] && vllm_url="${vllm_url}/v1"
+            RUN_ARGS+=(-e "VLLM_URL=${vllm_url}")
+        fi
+        if [[ -n "${VLLM_API_TOKEN:-}" ]]; then
+            RUN_ARGS+=(-e "VLLM_API_TOKEN=${VLLM_API_TOKEN}")
+        fi
+
+        # Forward VLLM_EMBEDDING_URL with /v1 suffix if needed
+        if [[ -n "${VLLM_EMBEDDING_URL:-}" ]]; then
+            local embed_url="${VLLM_EMBEDDING_URL}"
+            [[ "${embed_url}" != */v1 ]] && embed_url="${embed_url}/v1"
+            RUN_ARGS+=(-e "VLLM_EMBEDDING_URL=${embed_url}")
+        fi
+        if [[ -n "${VLLM_EMBEDDING_API_TOKEN:-}" ]]; then
+            RUN_ARGS+=(-e "VLLM_EMBEDDING_API_TOKEN=${VLLM_EMBEDDING_API_TOKEN}")
+        fi
+
+        # pgvector enabled by default — we always start postgres
+        ENABLE_PGVECTOR="${ENABLE_PGVECTOR:-1}"
+        if [[ -n "${ENABLE_PGVECTOR:-}" ]]; then
+            PGVECTOR_HOST="${PGVECTOR_HOST:-${postgres_host}}"
+            PGVECTOR_PORT="${PGVECTOR_PORT:-5432}"
+            PGVECTOR_DB="${PGVECTOR_DB:-${POSTGRES_DB}}"
+            PGVECTOR_USER="${PGVECTOR_USER:-${POSTGRES_USER}}"
+            PGVECTOR_PASSWORD="${PGVECTOR_PASSWORD:-${POSTGRES_PASSWORD}}"
+            export PGVECTOR_HOST PGVECTOR_PORT PGVECTOR_DB PGVECTOR_USER PGVECTOR_PASSWORD
+        fi
+
+        # Mount GCP credentials via podman secret if the file exists
+        if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && [[ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+            podman secret create --replace=true gcp-credentials "${GOOGLE_APPLICATION_CREDENTIALS}" >/dev/null 2>&1
+            RUN_ARGS+=(
+                --secret gcp-credentials
+                -e "GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gcp-credentials"
+            )
+        fi
+
+        # Forward remaining provider vars if set
+        for var in "${FORWARD_VARS[@]}"; do
+            if [[ -n "${!var:-}" ]]; then
+                RUN_ARGS+=(-e "${var}=${!var}")
+            fi
+        done
+    fi
+
+    # Print sanitized command
+    echo -e "${BLUE}podman run -d${NC}"
+    for arg in "${RUN_ARGS[@]}"; do
+        if [[ "$arg" =~ ^([A-Z0-9_]+)=(.*)$ ]]; then
+            local env_key="${BASH_REMATCH[1]}"
+            if [[ "$env_key" =~ $SENSITIVE_KEYS_REGEX ]]; then
+                echo -e "  ${BLUE}${env_key}=********${NC}"
+                continue
+            fi
+        fi
+        echo -e "  ${BLUE}${arg}${NC}"
+    done
+    echo -e "  ${BLUE}${OGX_IMAGE}${NC}"
+
+    podman run -d "${RUN_ARGS[@]}" "${OGX_IMAGE}"
+
+    sleep 3
+    wait_for_health
+}
+
+wait_for_health() {
+    local health_url="http://localhost:${OGX_PORT}/v1/health"
+    local max_attempts=60
+    local ogx_container
+    if [[ "$ITS_MODE" == true ]]; then
+        ogx_container="${POD_NAME}-ogx"
+    else
+        ogx_container="${CONTAINER_NAME_OGX}"
+    fi
+
+    echo -e "${BLUE}Waiting for OGX health check...${NC}"
+
+    for i in $(seq 1 $max_attempts); do
+        local response http_code body
+        response=$(curl -s -w "\n%{http_code}" "${health_url}" 2>/dev/null || echo -e "\n000")
+        http_code=$(echo "$response" | tail -n1)
+        body=$(echo "$response" | head -n-1)
+
+        if [[ "$http_code" == "200" ]]; then
+            if echo "$body" | grep -q '"status".*"OK"'; then
+                echo -e "${GREEN}OGX is healthy!${NC}"
+                return 0
+            fi
+        fi
+
+        if (( i % 5 == 0 )); then
+            echo -e "${YELLOW}  Attempt ${i}/${max_attempts}... (HTTP ${http_code})${NC}"
+        fi
+        sleep 2
+    done
+
+    echo -e "${RED}Health check failed after ${max_attempts} attempts.${NC}" >&2
+    echo "Check logs: podman logs ${ogx_container}" >&2
+    podman logs "${ogx_container}" 2>&1 | tail -30
+    exit 1
+}
+
+discover_model() {
+    if [[ -n "${INFERENCE_MODEL:-}" ]]; then
+        echo "Using pre-set INFERENCE_MODEL=${INFERENCE_MODEL}"
+        return 0
+    fi
+
+    local models_url="http://localhost:${OGX_PORT}/v1/models"
+    echo "Discovering inference model from ${models_url}..."
+
+    local response
+    response=$(curl -sS "${models_url}") || {
+        echo -e "${RED}Failed to query /v1/models${NC}" >&2
+        exit 1
+    }
+
+    INFERENCE_MODEL=$(python3 -c "
+import json, sys, os
+data = json.loads(sys.stdin.read())
+prov = os.environ.get('INFERENCE_PROVIDER', '')
+candidates = [m['id'] for m in data.get('data', [])
+              if (m.get('custom_metadata') or {}).get('model_type') != 'embedding']
+if prov:
+    preferred = [c for c in candidates if c.startswith(prov + '/')]
+    print(preferred[0] if preferred else (candidates[0] if candidates else ''))
+else:
+    print(candidates[0] if candidates else '')
+" <<< "$response")
+
+    if [[ -z "$INFERENCE_MODEL" ]]; then
+        echo -e "${RED}No non-embedding model found on the server.${NC}" >&2
+        echo "Response:" >&2
+        python3 -m json.tool <<< "$response" 2>/dev/null || echo "$response" >&2
+        exit 1
+    fi
+
+    export INFERENCE_MODEL
+    echo -e "${GREEN}Discovered model: ${INFERENCE_MODEL}${NC}"
+}
+
+discover_embedding_model() {
+    if [[ -n "${EMBEDDING_MODEL:-}" ]]; then
+        echo "Using pre-set EMBEDDING_MODEL=${EMBEDDING_MODEL}"
+        return 0
+    fi
+
+    local models_url="http://localhost:${OGX_PORT}/v1/models"
+    echo "Discovering embedding model from ${models_url}..."
+
+    local response
+    response=$(curl -sS "${models_url}") || {
+        echo -e "${YELLOW}Failed to query /v1/models for embedding — skipping${NC}" >&2
+        return 0
+    }
+
+    EMBEDDING_MODEL=$(python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+candidates = []
+for m in data.get('data', []):
+    meta = m.get('custom_metadata', {}) or {}
+    if meta.get('model_type') == 'embedding':
+        candidates.append(m['id'])
+# Prefer vllm-embedding provider (remote, always works) over sentence-transformers (local-only)
+for c in candidates:
+    if c.startswith('vllm-embedding/'):
+        print(c); sys.exit(0)
+print(candidates[0] if candidates else '')
+" <<< "$response")
+
+    if [[ -z "$EMBEDDING_MODEL" ]]; then
+        echo -e "${YELLOW}No embedding model found on the server.${NC}"
+        return 0
+    fi
+
+    export EMBEDDING_MODEL
+    echo -e "${GREEN}Discovered embedding model: ${EMBEDDING_MODEL}${NC}"
+}
+
+discover_providers() {
+    local providers_url="http://localhost:${OGX_PORT}/v1/providers"
+    echo "Discovering providers from ${providers_url}..."
+
+    local response
+    response=$(curl -sS "${providers_url}" 2>/dev/null) || {
+        echo -e "${YELLOW}Failed to query /v1/providers — skipping${NC}" >&2
+        return 0
+    }
+
+    while IFS='=' read -r key value; do
+        [[ -z "$key" ]] && continue
+        export "$key=$value"
+    done < <(python3 -c "
+import json, sys, re
+data = json.loads(sys.stdin.read()).get('data', [])
+api_map = {}
+for p in data:
+    api = p.get('api', '')
+    pid = p.get('provider_id', '')
+    if api and pid and api not in api_map and re.fullmatch(r'[a-zA-Z0-9_.:-]+', pid):
+        api_map[api] = pid
+for k in ('inference', 'files', 'vector_io'):
+    if k in api_map:
+        print(f'{k.upper()}_PROVIDER={api_map[k]}')
+" <<< "$response")
+
+    export INFERENCE_PROVIDER="${INFERENCE_PROVIDER:-}"
+    export FILES_PROVIDER="${FILES_PROVIDER:-}"
+    export VECTOR_IO_PROVIDER="${VECTOR_IO_PROVIDER:-}"
+    echo -e "${GREEN}Discovered providers: inference=${INFERENCE_PROVIDER} files=${FILES_PROVIDER} vector_io=${VECTOR_IO_PROVIDER}${NC}"
+}
+
+run_tests() {
+    export BASE_URL="http://localhost:${OGX_PORT}"
+    export INFERENCE_MODEL
+    export EMBEDDING_MODEL="${EMBEDDING_MODEL:-}"
+    export INFERENCE_PROVIDER="${INFERENCE_PROVIDER:-}"
+    export FILES_PROVIDER="${FILES_PROVIDER:-}"
+    export VECTOR_IO_PROVIDER="${VECTOR_IO_PROVIDER:-}"
+    # MCP test server runs on the host; OGX in a container can't reach host's localhost.
+    # Use host.containers.internal (podman's host gateway) for both pod and bridge modes.
+    # In Konflux ITS (real Kubernetes pod), override to http://localhost:${MCP_PORT}.
+    export MCP_SERVER_URL="${MCP_SERVER_URL:-http://host.containers.internal:${MCP_PORT:-8322}}"
+
+    echo -e "${GREEN}Running functional tests...${NC}"
+    echo "  BASE_URL=${BASE_URL}"
+    echo "  INFERENCE_MODEL=${INFERENCE_MODEL}"
+    echo "  EMBEDDING_MODEL=${EMBEDDING_MODEL}"
+    echo "  MCP_SERVER_URL=${MCP_SERVER_URL}"
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    "${script_dir}/run-tests-with-providers.sh"
+}
+
+cleanup() {
+    if [[ "$ITS_MODE" == true ]]; then
+        echo -e "${YELLOW}Removing pod: ${POD_NAME}${NC}"
+        podman pod rm -f "$POD_NAME" 2>/dev/null || true
+        echo -e "${GREEN}Pod removed.${NC}"
+    else
+        echo -e "${YELLOW}Cleaning up containers...${NC}"
+        for c in "${CONTAINER_NAME_OGX}" "${CONTAINER_NAME_PG}"; do
+            podman rm -f "$c" 2>/dev/null || true
+        done
+        echo -e "${GREEN}Containers removed.${NC}"
+        echo "Network '${NETWORK_NAME}' and volume '${VOLUME_NAME}' kept for fast restarts."
+        echo "To remove: podman network rm ${NETWORK_NAME}; podman volume rm ${VOLUME_NAME}"
+    fi
+}
+
+print_status() {
+    echo ""
+    echo "========================================"
+    if [[ "$ITS_MODE" == true ]]; then
+        echo -e "${GREEN}ITS pod is running: ${POD_NAME}${NC}"
+    else
+        echo -e "${GREEN}Infrastructure is running.${NC}"
+    fi
+    echo "========================================"
+    echo "  OGX server:  http://localhost:${OGX_PORT}"
+    if [[ "$ITS_MODE" == true ]]; then
+        echo "  vLLM inference:  http://localhost:8000  (${VLLM_INFERENCE_MODEL})"
+        echo "  vLLM embedding:  http://localhost:8001  (${VLLM_EMBEDDING_MODEL})"
+    fi
+    echo "  PostgreSQL:  localhost:${POSTGRES_PORT}"
+    echo "  INFERENCE_MODEL:       ${INFERENCE_MODEL}"
+    echo "  Image:       ${OGX_IMAGE}"
+    echo ""
+    echo "Run tests:"
+    if [[ "$ITS_MODE" == true ]]; then
+        echo "  ./scripts/setup-server.sh --its --tests-only"
+    else
+        echo "  ./scripts/setup-server.sh --tests-only"
+    fi
+    echo "  # or manually:"
+    echo "  BASE_URL=http://localhost:${OGX_PORT} INFERENCE_MODEL=${INFERENCE_MODEL} ./scripts/run-tests-with-providers.sh"
+    echo ""
+    echo "Logs:"
+    if [[ "$ITS_MODE" == true ]]; then
+        echo "  podman logs -f ${POD_NAME}-ogx"
+        echo "  podman logs -f ${POD_NAME}-vllm-inference"
+        echo "  podman logs -f ${POD_NAME}-vllm-embedding"
+    else
+        echo "  podman logs -f ${CONTAINER_NAME_OGX}"
+    fi
+    echo ""
+    echo "Cleanup:"
+    if [[ "$ITS_MODE" == true ]]; then
+        echo "  ./scripts/setup-server.sh --its --cleanup"
+    else
+        echo "  ./scripts/setup-server.sh --cleanup"
+    fi
+
+    if [[ "$ITS_MODE" == true ]]; then
+        echo ""
+        echo "Containers:"
+        podman ps --filter "pod=${POD_NAME}" --format "table {{.Names}}\t{{.Image}}\t{{.Status}}"
+    fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+check_prerequisites
+
+case "$MODE" in
+    cleanup)
+        cleanup
+        ;;
+
+    tests-only)
+        export BASE_URL="${BASE_URL:-http://localhost:${OGX_PORT}}"
+        # Verify server is reachable
+        if ! curl -fsS "${BASE_URL}/v1/health" >/dev/null 2>&1; then
+            echo -e "${RED}No OGX server at ${BASE_URL}${NC}" >&2
+            echo "Start one first, or run without --tests-only for full setup." >&2
+            exit 1
+        fi
+        echo -e "${GREEN}Found running OGX at ${BASE_URL}${NC}"
+        discover_providers
+        discover_model
+        discover_embedding_model
+        run_tests
+        ;;
+
+    start-only)
+        if [[ "$ITS_MODE" == true ]]; then
+            create_pod
+        fi
+        start_postgres
+        if [[ "$ITS_MODE" == true ]]; then
+            start_vllm_inference
+            start_vllm_embedding
+        fi
+        start_ogx
+        discover_providers
+        discover_model
+        discover_embedding_model
+        print_status
+        ;;
+
+    full)
+        if [[ "$DO_CLEANUP" == true ]]; then
+            trap cleanup EXIT
+        fi
+        if [[ "$ITS_MODE" == true ]]; then
+            create_pod
+        fi
+        start_postgres
+        if [[ "$ITS_MODE" == true ]]; then
+            start_vllm_inference
+            start_vllm_embedding
+        fi
+        start_ogx
+        discover_providers
+        discover_model
+        discover_embedding_model
+        run_tests
+        echo -e "${GREEN}All tests passed!${NC}"
+        ;;
+esac

--- a/tests/functional/scripts/sync-client-version.sh
+++ b/tests/functional/scripts/sync-client-version.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2317
+# Ensure the installed ogx-client matches the target server.
+#
+# Version source (in priority order):
+#   1. Running server at BASE_URL/v1/version
+#   2. build/build.env OGX_VERSION (same-repo fallback, no server needed)
+#
+# Requires: python3, uv. BASE_URL optional if build.env is available.
+
+set -euo pipefail
+
+if [[ "${SKIP_CLIENT_SYNC:-0}" == "1" ]]; then
+  echo "Client version sync skipped (SKIP_CLIENT_SYNC=1)"
+  return 0 2>/dev/null || exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_ROOT="$(cd "${REPO_ROOT}/../.." && pwd)"
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+BUILD_ENV="${DIST_ROOT}/build/build.env"
+
+_server_version=""
+if [[ -n "${BASE_URL:-}" ]]; then
+  _server_version=$(curl -sf "${BASE_URL}/v1/version" | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || true)
+fi
+
+if [[ -z "$_server_version" && -f "$BUILD_ENV" ]]; then
+  _server_version=$(grep -oP '^OGX_VERSION=\K.*' "$BUILD_ENV" | sed 's/^v//' || true)
+  if [[ -n "$_server_version" ]]; then
+    echo "Using OGX version from build/build.env: ${_server_version}"
+  fi
+fi
+
+if [[ -z "$_server_version" ]]; then
+  echo "Warning: could not determine OGX version (no server at ${BASE_URL:-<unset>}, no build/build.env) — skipping client sync" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+# Strip build metadata (e.g. 0.7.1+rhaiv.1 → 0.7.1)
+_server_base="${_server_version%%+*}"
+_server_major_minor="${_server_base%.*}"
+
+_client_version=$(uv run --project "${REPO_ROOT}" python3 -c "import ogx_client; print(ogx_client.__version__)" 2>/dev/null || echo "0.0.0")
+_client_major_minor="${_client_version%.*}"
+
+if [[ "$_client_major_minor" == "$_server_major_minor" ]]; then
+  echo "Client ${_client_version} matches server ${_server_version} (both ${_server_major_minor}.x)"
+  return 0 2>/dev/null || exit 0
+fi
+
+if ! [[ "$_server_major_minor" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: unexpected server version format: ${_server_version}" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "Version mismatch: client=${_client_version}, server=${_server_version}"
+echo "Updating pyproject.toml to require ogx-client~=${_server_major_minor}.0 ..."
+
+# Update the version constraint in pyproject.toml
+sed -i "s|\"ogx-client[^\"]*\"|\"ogx-client~=${_server_major_minor}.0\"|" "${PYPROJECT}"
+
+# Re-sync the venv (updates uv.lock and installs the right version)
+(cd "${REPO_ROOT}" && uv sync --quiet)
+
+_new_version=$(uv run --project "${REPO_ROOT}" python3 -c "import ogx_client; print(ogx_client.__version__)" 2>/dev/null)
+echo "Upgraded ogx-client: ${_client_version} -> ${_new_version}"

--- a/tests/functional/tests/test_notebooks.py
+++ b/tests/functional/tests/test_notebooks.py
@@ -1,0 +1,36 @@
+"""
+Run Jupyter notebooks as tests: verify each notebook executes to completion without
+unhandled exceptions. Uses pytest + nbformat + nbconvert (ExecutePreprocessor).
+See: https://blog.iqmo.com/blog/python/jupyter_notebook_testing/
+"""
+
+import pytest
+from pathlib import Path
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOK_DIR = REPO_ROOT / "notebooks"
+# Notebooks to skip (e.g. long-running, demo-only, or replaced by split test notebooks)
+SKIP_NOTEBOOKS = []
+TIMEOUT = 600  # seconds per notebook
+
+
+def _collect_notebooks():
+    if not NOTEBOOK_DIR.exists():
+        return []
+    return [
+        f for f in sorted(NOTEBOOK_DIR.glob("*.ipynb")) if f.name not in SKIP_NOTEBOOKS
+    ]
+
+
+@pytest.mark.parametrize("notebook", _collect_notebooks(), ids=lambda p: p.name)
+def test_notebook_execution(notebook: Path):
+    """Run notebook to completion; fail on any unhandled exception."""
+    with open(notebook) as f:
+        nb = nbformat.read(f, as_version=4)
+    assert any("assert " in c.source for c in nb.cells if c.cell_type == "code"), (
+        f"{notebook.name} has no assert statements"
+    )
+    ep = ExecutePreprocessor(timeout=TIMEOUT)
+    ep.preprocess(nb)


### PR DESCRIPTION
## Summary

Functional test framework for OGX distribution under `tests/functional/`:

- **Bruno CRUD tests** — 1 admin request (List Providers) as a starting point
- **Notebook runner** — pytest + nbconvert executor (`test_basic_inference.ipynb`)
- **Scripts** — test orchestrator, local ITS emulation (`setup-server.sh --its`), ogx-client version sync
- **Containerfile** — test runner image for Konflux ITS

20 files, ~2k lines.

## Related PRs

- [#467](https://github.com/opendatahub-io/ogx-distribution/pull/467) — Bruno CRUD tests (25 requests, 48 assertions) — depends on this PR
- [#430](https://github.com/opendatahub-io/ogx-distribution/pull/430) — 8 notebooks (RAG, MCP, streaming) — depends on this PR
- [odh-konflux-central#435](https://github.com/opendatahub-io/odh-konflux-central/pull/435) — Konflux ITS pipeline

## Test plan

- [x] Pre-commit passes
- [x] Local ITS: `./scripts/setup-server.sh --its` — all green