### PR TITLE
fix: run vLLM CPU image as non-root and drop --privileged

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -8,6 +8,10 @@ runs:
       run: |
         # Read MODEL_CACHE_DIR from the image so the action works with both
         # old images (/root/.cache) and new images (/opt/vllm/models).
+        # Pull if not already present (locally-built images are already loaded).
+        if ! docker image inspect "$VLLM_IMAGE" >/dev/null 2>&1; then
+          docker pull "$VLLM_IMAGE"
+        fi
         MODEL_DIR=$(docker inspect "$VLLM_IMAGE" --format '{{range .Config.Env}}{{println .}}{{end}}' \
           | grep '^MODEL_CACHE_DIR=' | cut -d= -f2)
         MODEL_DIR="${MODEL_DIR:-/opt/vllm/models}"

--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -8,10 +8,10 @@ runs:
       run: |
         # Set VLLM_ARGS based on VLLM_MODE
         if [[ "$VLLM_MODE" == "inference" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enforce-eager --language-model-only --skip-mm-profiling --enable-auto-tool-choice --tool-call-parser hermes --model /root/.cache/Qwen/Qwen3.5-0.8B --served-model-name Qwen/Qwen3.5-0.8B --max-model-len 8192 --gpu-memory-utilization 0.50"
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enforce-eager --language-model-only --skip-mm-profiling --enable-auto-tool-choice --tool-call-parser hermes --model /opt/vllm/models/Qwen/Qwen3.5-0.8B --served-model-name Qwen/Qwen3.5-0.8B --max-model-len 8192 --gpu-memory-utilization 0.50"
           VLLM_PORT=8000
         elif [[ "$VLLM_MODE" == "embedding" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /root/.cache/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english --gpu-memory-utilization 0.25"
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english --gpu-memory-utilization 0.25"
           VLLM_PORT=8001
         else
           echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"
@@ -21,7 +21,6 @@ runs:
         # Start vllm container
         docker run -d \
           --name vllm-$VLLM_MODE \
-          --privileged=true \
           --net=host \
           $VLLM_IMAGE \
           $VLLM_ARGS

--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -6,12 +6,18 @@ runs:
     - name: Start vLLM container
       shell: bash
       run: |
+        # Read MODEL_CACHE_DIR from the image so the action works with both
+        # old images (/root/.cache) and new images (/opt/vllm/models).
+        MODEL_DIR=$(docker inspect "$VLLM_IMAGE" --format '{{range .Config.Env}}{{println .}}{{end}}' \
+          | grep '^MODEL_CACHE_DIR=' | cut -d= -f2)
+        MODEL_DIR="${MODEL_DIR:-/opt/vllm/models}"
+
         # Set VLLM_ARGS based on VLLM_MODE
         if [[ "$VLLM_MODE" == "inference" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enforce-eager --language-model-only --skip-mm-profiling --enable-auto-tool-choice --tool-call-parser hermes --model /opt/vllm/models/Qwen/Qwen3.5-0.8B --served-model-name Qwen/Qwen3.5-0.8B --max-model-len 8192 --gpu-memory-utilization 0.50"
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enforce-eager --language-model-only --skip-mm-profiling --enable-auto-tool-choice --tool-call-parser hermes --model ${MODEL_DIR}/Qwen/Qwen3.5-0.8B --served-model-name Qwen/Qwen3.5-0.8B --max-model-len 8192 --gpu-memory-utilization 0.50"
           VLLM_PORT=8000
         elif [[ "$VLLM_MODE" == "embedding" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english --gpu-memory-utilization 0.25"
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model ${MODEL_DIR}/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english --gpu-memory-utilization 0.25"
           VLLM_PORT=8001
         else
           echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"

--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -12,7 +12,7 @@ ARG EMBEDDING_MODEL=""
 
 ENV INFERENCE_MODEL="${INFERENCE_MODEL}"
 ENV EMBEDDING_MODEL="${EMBEDDING_MODEL}"
-ENV MODEL_CACHE_DIR="/root/.cache"
+ENV MODEL_CACHE_DIR="/opt/vllm/models"
 
 RUN if [ -z "${INFERENCE_MODEL}" ]; then \
         echo "ERROR: INFERENCE_MODEL build argument is required" >&2 && exit 1; \
@@ -32,7 +32,9 @@ RUN --mount=type=secret,id=hf_token \
         else \
             hf download "${model}" --local-dir "${model_path}"; \
         fi && \
-        rm -rf /root/.cache/huggingface "${model_path}/original"; \
+        rm -rf "${MODEL_CACHE_DIR}/.huggingface" "${model_path}/original"; \
     done
+
+USER 1001
 
 ENTRYPOINT ["vllm", "serve"]

--- a/vllm/Containerfile
+++ b/vllm/Containerfile
@@ -35,6 +35,7 @@ RUN --mount=type=secret,id=hf_token \
         rm -rf "${MODEL_CACHE_DIR}/.huggingface" "${model_path}/original"; \
     done
 
+RUN useradd -r -u 1001 -m vllm
 USER 1001
 
 ENTRYPOINT ["vllm", "serve"]

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -47,14 +47,13 @@ The entrypoint is `vllm serve`, so pass model and serving arguments directly. Th
 ```bash
 docker run -d \
     --name vllm-inference \
-    --privileged=true \
     --net=host \
     vllm-cpu:Qwen3.5-0.8B-granite-embedding-125m-english \
     --host 0.0.0.0 \
     --port 8000 \
     --enable-auto-tool-choice \
     --tool-call-parser hermes \
-    --model /root/.cache/Qwen/Qwen3.5-0.8B \
+    --model /opt/vllm/models/Qwen/Qwen3.5-0.8B \
     --served-model-name Qwen/Qwen3.5-0.8B \
     --max-model-len 8192
 ```
@@ -64,14 +63,13 @@ docker run -d \
 ```bash
 docker run -d \
     --name vllm-embedding \
-    --privileged=true \
     --net=host \
     vllm-cpu:Qwen3.5-0.8B-granite-embedding-125m-english \
     --host 0.0.0.0 \
     --port 8001 \
-    --model /root/.cache/ibm-granite/granite-embedding-125m-english \
+    --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english \
     --served-model-name ibm-granite/granite-embedding-125m-english
 ```
 
 > [!TIP]
-> Additional vLLM arguments can be passed directly. Models are stored under `/root/.cache/<model_id>`.
+> Additional vLLM arguments can be passed directly. Models are stored under `/opt/vllm/models/<model_id>`.


### PR DESCRIPTION
## Summary
- Move vLLM CPU model storage from `/root/.cache` to `/opt/vllm/models` and add `USER 1001` so the container no longer runs as root
- Remove `--privileged=true` from the CI action and README examples — it's unnecessary for a userspace Python inference server
- Update all model path references in the CI action and documentation to match

## Test plan
- [x] CI vLLM container build succeeds with new `MODEL_CACHE_DIR`
- [x] Smoke/integration tests pass with updated model paths and without `--privileged`
- [x] Verify container process runs as UID 1001 (e.g. `docker exec vllm-inference id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * vLLM container now uses /opt/vllm/models and drops --privileged in run commands.
  * CI workflow: Python 3.11 + two-step pre-commit (auto-fix then verify).
  * Bumped OGX version and updated dependency pins and constraints; adjusted message provider backend to use a kvstore.

* **Documentation**
  * Updated vLLM and distribution README examples and version references to match container changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->