### PR TITLE
feat: support release-* branch scheme in CI/CD and auto-merge

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - or:
           - base=main
           - base~=^rhoai-v
+          - base~=^release-
       - label!=do-not-merge
       - label!=needs-rebase
       - check-success=pre-commit
@@ -35,6 +36,7 @@ pull_request_rules:
       - or:
           - base=main
           - base~=^rhoai-v
+          - base~=^release-
       - label!=do-not-merge
       - label!=needs-rebase
       - check-success=pre-commit

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - rhoai-v*
+      - release-*
       - konflux-poc*
     types:
       - opened
@@ -21,6 +22,7 @@ on:
     branches:
       - main
       - rhoai-v*
+      - release-*
 
   # build a custom image from an arbitrary ogx commit
   # NOTE: workflow_dispatch intentionally skips all tests (vllm setup, postgres setup, smoke tests, integration tests)
@@ -392,6 +394,16 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
+      - name: Compute branch-specific image tag
+        if: github.event_name == 'push'
+        run: |
+          if [[ "$GITHUB_REF" == refs/heads/rhoai-v* ]]; then
+            echo "BRANCH_TAG=${GITHUB_REF_NAME}-latest" >> "$GITHUB_ENV"
+          elif [[ "$GITHUB_REF" == refs/heads/release-* ]]; then
+            version="${GITHUB_REF_NAME#release-}"
+            echo "BRANCH_TAG=rhoai-v${version}-latest" >> "$GITHUB_ENV"
+          fi
+
       - name: Publish multi-arch image to Quay.io
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -399,7 +411,7 @@ jobs:
           file: Containerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ github.event_name == 'workflow_dispatch' && format('{0}:source-{1}-{2}', env.IMAGE_NAME, env.OGX_COMMIT_SHA, github.sha) || format('{0}:{1}{2}', env.IMAGE_NAME, github.sha, github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || (startsWith(github.ref, 'refs/heads/rhoai-v') && format(',{0}:{1}-latest', env.IMAGE_NAME, github.ref_name)) || '') }}
+          tags: ${{ github.event_name == 'workflow_dispatch' && format('{0}:source-{1}-{2}', env.IMAGE_NAME, env.OGX_COMMIT_SHA, github.sha) || format('{0}:{1}{2}', env.IMAGE_NAME, github.sha, github.ref == 'refs/heads/main' && format(',{0}:latest', env.IMAGE_NAME) || (env.BRANCH_TAG != '' && format(',{0}:{1}', env.IMAGE_NAME, env.BRANCH_TAG)) || '') }}
           cache-from: |
             type=gha,scope=build-amd64
             type=gha,scope=build-arm64

--- a/.github/workflows/vllm-cpu-container.yml
+++ b/.github/workflows/vllm-cpu-container.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - rhoai-v*
+      - release-*
       - konflux-poc*
     types:
       - opened
@@ -17,6 +18,7 @@ on:
     branches:
       - main
       - rhoai-v*
+      - release-*
     paths:
       - 'vllm/Containerfile'
       - '.github/actions/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,10 @@ The OGX version is set in `build/build.env` (`OGX_VERSION`). The build script (`
 
 ### CI/CD
 
-- **`redhat-distro-container.yml`** — main workflow: builds multi-arch images, runs smoke + integration tests against vLLM (local CPU or MaaS) and PostgreSQL, publishes to Quay.io on push to `main`/`rhoai-v*`. Nightly scheduled builds test against OGX `main`.
+- **`redhat-distro-container.yml`** — main workflow: builds multi-arch images, runs smoke + integration tests against vLLM (local CPU or MaaS) and PostgreSQL, publishes to Quay.io on push to `main`/`rhoai-v*`/`release-*`. Nightly scheduled builds test against OGX `main`.
 - **`responses-weekly.yml`** — weekly Responses API test suite across OpenAI, Vertex AI, and vLLM MaaS providers; publishes results to GitHub Pages.
 - **Tekton** (`.tekton/`) — Konflux/RHOAI downstream build pipelines.
-- **`create-or-update-release-branch.yml`** — creates/updates `rhoai-v*` release branches.
+- **`create-or-update-release-branch.yml`** — creates/updates `release-*` release branches.
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Various tags are maintained for this image:
 
 - `latest` will always point to the latest image that has been built off of a merge to the `main` branch
   - You can also pull an older image built off of `main` by using the SHA of the merge commit as the tag
-- `rhoai-v*-latest` will always point to the latest image that has been built off of a merge to the corresponding `rhoai-v*` branch
+- `rhoai-v*-latest` will always point to the latest image that has been built off of a merge to the corresponding `rhoai-v*` or `release-*` branch (e.g., a push to `release-3.5-ea.2` produces the tag `rhoai-v3.5-ea.2-latest`)
 
 You can see the source code that implements this build strategy [here](.github/workflows/redhat-distro-container.yml)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,8 +141,8 @@ Testing is automated via GitHub Actions workflows in `.github/workflows/`.
 
 The main CI pipeline that builds, tests, and publishes the container image. It runs on:
 
-- **Pull requests** to `main`, `rhoai-v*`, and `konflux-poc*` branches (when `distribution/`, `Containerfile`, `tests/`, or workflow files change)
-- **Pushes** to `main` and `rhoai-v*` branches
+- **Pull requests** to `main`, `rhoai-v*`, `release-*`, and `konflux-poc*` branches (when `distribution/`, `Containerfile`, `tests/`, or workflow files change)
+- **Pushes** to `main`, `rhoai-v*`, and `release-*` branches
 - **Manual dispatch** (`workflow_dispatch`) to build from an arbitrary ogx commit. Intentionally skips all tests to allow building images for specific SHAs even when CI is failing on other commits
 - **Nightly schedule** (6 AM UTC) to test the `main` branch of ogx
 
@@ -154,7 +154,7 @@ Pipeline steps:
 4. **Start PostgreSQL** via the `setup-postgres` action
 5. **Run smoke tests** (`tests/smoke.sh`)
 6. **Run integration tests** (`tests/run_integration_tests.sh`)
-7. **Publish** multi-arch image to `quay.io/opendatahub/odh-ogx-core` (on push to `main` or `rhoai-v*` branches when `distribution/` or `Containerfile` changed, or on manual dispatch)
+7. **Publish** multi-arch image to `quay.io/opendatahub/odh-ogx-core` (on push to `main`, `rhoai-v*`, or `release-*` branches when `distribution/` or `Containerfile` changed, or on manual dispatch)
 8. **Notify Slack** on failure or successful publish
 
 Logs from all containers (ogx, vLLM, PostgreSQL) and system info are uploaded as artifacts with 7-day retention.
@@ -213,7 +213,7 @@ Triggered via `repository_dispatch` (type: `update-ogx-version`) from the openda
 
 Builds, tests, and publishes pre-built vLLM CPU container images to `quay.io/opendatahub/vllm-cpu`. These images bundle inference and embedding models so the main CI pipeline doesn't need to download them each run. It runs on:
 
-- **Pull requests** to `main`/`rhoai-v*`/`konflux-poc*` branches and **pushes** to `main`/`rhoai-v*` branches (when `vllm/Containerfile` or actions change)
+- **Pull requests** to `main`/`rhoai-v*`/`release-*`/`konflux-poc*` branches and **pushes** to `main`/`rhoai-v*`/`release-*` branches (when `vllm/Containerfile` or actions change)
 - **Manual dispatch** with optional custom inference/embedding model parameters
 
 ### Test PR in Showroom (`test-pr-in-showroom.yml`)


### PR DESCRIPTION
## Summary

- Adds `release-*` alongside `rhoai-v*` in all workflow branch triggers (`redhat-distro-container.yml`, `vllm-cpu-container.yml`) and Mergify auto-merge rules
- Pushes to `release-*` branches produce the same `rhoai-v*-latest` Quay tag style (e.g., `release-3.5-ea.2` → `rhoai-v3.5-ea.2-latest`)
- Extracts the branch-specific tag computation into its own step for clarity, replacing the inline `startsWith` expression

Ref: https://github.com/opendatahub-io/ogx-distribution/pull/395

## Test plan

- [ ] Verify actionlint passes (pre-commit clean)
- [ ] Push to a `release-*` branch and confirm the workflow triggers and the correct `rhoai-v*-latest` tag is produced
- [ ] Open a PR targeting a `release-*` branch and confirm Mergify auto-merge conditions match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD pipelines to support `release-*` branch patterns alongside existing `main` and `rhoai-v*` branches for automated builds and publishing.
  
* **Documentation**
  * Updated documentation to clarify container image tagging behavior for releases from both `rhoai-v*` and `release-*` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->