### PR TITLE
fix(ci): retry CREATE EXTENSION until database is ready

### DIFF
--- a/.github/actions/setup-postgres/action.yml
+++ b/.github/actions/setup-postgres/action.yml
@@ -32,6 +32,14 @@ runs:
           exit 1
         fi
 
-        # Enable pgvector extension (image ships the .so, but the DB needs CREATE EXTENSION)
-        docker exec postgres psql -U ogx -d ogx -c "CREATE EXTENSION IF NOT EXISTS vector;"
-        echo "pgvector extension enabled"
+        # Enable pgvector extension (image ships the .so, but the DB needs CREATE EXTENSION).
+        # pg_isready returns true before the database is fully initialized, so retry.
+        echo "Enabling pgvector extension..."
+        for i in {1..10}; do
+          if docker exec postgres psql -U ogx -d ogx -c "CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; then
+            echo "pgvector extension enabled"
+            break
+          fi
+          echo "Attempt $i: database not ready for CREATE EXTENSION, retrying..."
+          sleep 1
+        done


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure introduced in #441 where `CREATE EXTENSION IF NOT EXISTS vector` fails with `FATAL: database "ogx" does not exist`.

`pg_isready` returns true before the database is fully initialized. The `CREATE EXTENSION` command now retries up to 10 times with 1s sleep.

## Context

The post-merge CI run on main ([#28036310464](https://github.com/opendatahub-io/ogx-distribution/actions/runs/28036310464)) failed because PostgreSQL accepted connections before the `ogx` database was created. PR #441's own CI passed because the race didn't surface on that run.

## Test plan

- [x] Retry loop handles the race — waits for database before running CREATE EXTENSION
- [ ] CI green on this PR