### PR TITLE
ci: log operator pod status after setup in upstream workflow

### DIFF
--- a/.github/workflows/test-upstream-in-showroom.yml
+++ b/.github/workflows/test-upstream-in-showroom.yml
@@ -108,6 +108,9 @@ jobs:
           echo -e "\n=== Pod Logs (last 150 lines) ==="
           oc logs -n redhat-ods-applications --tail=150 -l app=ogx || echo "No logs available"
 
+          echo -e "\n=== OGX Operator Logs (last 50 lines) ==="
+          oc logs -n redhat-ods-applications --tail=50 -l app.kubernetes.io/part-of=ogx || echo "No OGX operator logs available"
+
       - name: Run unprovision.sh
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- Log operator pod status after `setup.sh` completes in the upstream periodic CI workflow to help diagnose webhook and provisioning failures

## Motivation

The upstream CI has been failing intermittently during provisioning with webhook-related errors. Adding operator pod status output after setup will help determine whether the operator is fully ready before provisioning begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the always-run debug workflow to show the latest OGX operator logs (last 50 lines), including a clear message when no logs are available.
* **Dependencies**
  * Updated OpenTelemetry instrumentation packages to newer versions (for the pinned instrumentation libraries) to keep telemetry behavior current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->