### PR TITLE
feat: add Bruno CRUD tests (31 requests, 76 assertions)

### DIFF
--- a/tests/functional/bruno/ogx-api/01-admin/Get Health.bru
+++ b/tests/functional/bruno/ogx-api/01-admin/Get Health.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Health
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1alpha/admin/health
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Status is OK", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("status");
+    expect(body.status).to.eql("OK");
+  });
+}

--- a/tests/functional/bruno/ogx-api/01-admin/Get Version.bru
+++ b/tests/functional/bruno/ogx-api/01-admin/Get Version.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Version
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/v1alpha/admin/version
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has version string", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("version");
+    expect(body.version).to.be.a("string");
+  });
+}

--- a/tests/functional/bruno/ogx-api/01-admin/List Routes.bru
+++ b/tests/functional/bruno/ogx-api/01-admin/List Routes.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List Routes
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/v1alpha/admin/inspect/routes
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has routes array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+    expect(body.data.length).to.be.greaterThan(0);
+  });
+}

--- a/tests/functional/bruno/ogx-api/02-models/Get Model.bru
+++ b/tests/functional/bruno/ogx-api/02-models/Get Model.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get Model
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/models/{{model}}
+  body: none
+  auth: inherit
+}
+
+script:pre-request {
+  const model = bru.getEnvVar("model");
+  if (!/^[a-zA-Z0-9.\-_\/]+$/.test(model)) {
+    throw new Error("Invalid model identifier: " + model);
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has matching model identifier", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("identifier");
+    expect(body.identifier).to.be.a("string");
+    expect(body.identifier).to.eql(bru.getEnvVar("model"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/02-models/List Models.bru
+++ b/tests/functional/bruno/ogx-api/02-models/List Models.bru
@@ -1,7 +1,7 @@
 meta {
   name: List Models
   type: http
-  seq: 4
+  seq: 1
 }
 
 get {
@@ -14,22 +14,23 @@ tests {
   test("Status is 200", function() {
     expect(res.getStatus()).to.eql(200);
   });
-
-  test("Response has models array", function() {
+  test("Response has data array", function() {
     const body = res.getBody();
     expect(body).to.have.property("data");
     expect(body.data).to.be.an("array");
     expect(body.data.length).to.be.greaterThan(0);
+    body.data.forEach(item => {
+      expect(item).to.be.an("object");
+      expect(item).to.have.property("id").that.is.a("string");
+    });
   });
-
-  test("Inference model is registered", function() {
+  test("Configured inference model is registered", function() {
     const model = bru.getEnvVar("model");
     expect(model).to.be.a("string").and.not.empty;
     const ids = res.getBody().data.map(m => m.id);
     expect(ids).to.include(model);
   });
-
-  test("Embedding model is registered", function() {
+  test("Configured embedding model is registered", function() {
     const model = bru.getEnvVar("embedding_model");
     expect(model).to.be.a("string").and.not.empty;
     const ids = res.getBody().data.map(m => m.id);

--- a/tests/functional/bruno/ogx-api/03-inference/Create Chat Completion.bru
+++ b/tests/functional/bruno/ogx-api/03-inference/Create Chat Completion.bru
@@ -1,0 +1,54 @@
+meta {
+  name: Create Chat Completion
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/chat/completions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "{{model}}",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Say hello in one word."
+      }
+    ],
+    "max_tokens": 16
+  }
+}
+
+script:pre-request {
+  const model = bru.getEnvVar("model");
+  if (!/^[a-zA-Z0-9.\-_\/]+$/.test(model)) {
+    throw new Error("Invalid model identifier: " + model);
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has choices array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("choices");
+    expect(body.choices).to.be.an("array");
+    expect(body.choices.length).to.be.greaterThan(0);
+  });
+  test("First choice has message content", function() {
+    const body = res.getBody();
+    const msg = body.choices[0].message;
+    expect(msg).to.have.property("content");
+    expect(msg.content).to.be.a("string");
+  });
+  test("Response model matches configured model", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("model");
+    expect(body.model).to.eql(bru.getEnvVar("model"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/03-inference/Create Embedding.bru
+++ b/tests/functional/bruno/ogx-api/03-inference/Create Embedding.bru
@@ -1,0 +1,49 @@
+meta {
+  name: Create Embedding
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/embeddings
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "{{embedding_model}}",
+    "input": "OGX functional test embedding",
+    "encoding_format": "float"
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has data array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+    expect(body.data.length).to.be.greaterThan(0);
+  });
+  test("First embedding has correct structure", function() {
+    const item = res.getBody().data[0];
+    expect(item).to.have.property("embedding");
+    expect(item.embedding).to.be.an("array");
+    expect(item.embedding.length).to.be.greaterThan(0);
+  });
+  test("Embedding dimension matches configured value", function() {
+    const item = res.getBody().data[0];
+    const expectedDim = Number(bru.getEnvVar("embedding_dimension"));
+    expect(Number.isSafeInteger(expectedDim)).to.eql(true);
+    expect(expectedDim).to.be.greaterThan(0);
+    expect(item.embedding.length).to.eql(expectedDim);
+  });
+  test("Response model matches configured embedding model", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("model");
+    expect(body.model).to.eql(bru.getEnvVar("embedding_model"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/03-inference/Create Text Completion.bru
+++ b/tests/functional/bruno/ogx-api/03-inference/Create Text Completion.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Create Text Completion
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/v1/completions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "{{model}}",
+    "prompt": "The capital of France is",
+    "max_tokens": 32,
+    "temperature": 0
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has choices array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("choices");
+    expect(body.choices).to.be.an("array");
+    expect(body.choices.length).to.be.greaterThan(0);
+  });
+  test("First choice has text content", function() {
+    const body = res.getBody();
+    expect(body.choices[0]).to.have.property("text");
+    expect(body.choices[0].text).to.be.a("string");
+  });
+  test("Response model matches configured model", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("model");
+    expect(body.model).to.eql(bru.getEnvVar("model"));
+  });
+  test("Response contains expected keyword", function() {
+    const text = res.getBody().choices[0].text.toLowerCase();
+    expect(text).to.include("paris");
+  });
+}

--- a/tests/functional/bruno/ogx-api/03-inference/List Chat Completions.bru
+++ b/tests/functional/bruno/ogx-api/03-inference/List Chat Completions.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Chat Completions
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/chat/completions
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has data array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+  });
+}

--- a/tests/functional/bruno/ogx-api/04-files/Create File.bru
+++ b/tests/functional/bruno/ogx-api/04-files/Create File.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Create File
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/files
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file: @file(test-upload.txt)
+  purpose: assistants
+}
+
+tests {
+  test("Status is 200 or 201", function() {
+    expect([200, 201]).to.include(res.getStatus());
+  });
+  test("File created and ID saved", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.be.a("string");
+    bru.setVar("file_id", body.id);
+  });
+}

--- a/tests/functional/bruno/ogx-api/04-files/Delete File.bru
+++ b/tests/functional/bruno/ogx-api/04-files/Delete File.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete File
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/v1/files/{{file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200 or 204", function() {
+    expect([200, 204]).to.include(res.getStatus());
+  });
+}

--- a/tests/functional/bruno/ogx-api/04-files/Get File.bru
+++ b/tests/functional/bruno/ogx-api/04-files/Get File.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get File
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1/files/{{file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has matching file ID", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.eql(bru.getVar("file_id"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/04-files/List Files.bru
+++ b/tests/functional/bruno/ogx-api/04-files/List Files.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Files
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/files
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has data array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Attach File to Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Attach File to Vector Store.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Attach File to Vector Store
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/v1/vector_stores/{{vector_store_id}}/files
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "file_id": "{{vs_file_id}}",
+    "chunking_strategy": {
+      "type": "static",
+      "static": {
+        "max_chunk_size_tokens": 256,
+        "chunk_overlap_tokens": 32
+      }
+    }
+  }
+}
+
+tests {
+  test("Status is 200 or 201", function() {
+    expect([200, 201]).to.include(res.getStatus());
+  });
+  test("File attached to vector store", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body).to.have.property("status");
+    expect(body.status).to.eql("completed");
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Create Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Create Vector Store.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Create Vector Store
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/vector_stores
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "bruno-crud-test",
+    "provider_id": "{{vector_io_provider}}",
+    "embedding_model": "{{embedding_model}}",
+    "embedding_dimension": {{embedding_dimension}}
+  }
+}
+
+tests {
+  test("Status is 200 or 201", function() {
+    expect([200, 201]).to.include(res.getStatus());
+  });
+  test("Vector store created and ID saved", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.be.a("string");
+    bru.setVar("vector_store_id", body.id);
+  });
+  test("Vector store uses configured embedding model", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("metadata");
+    expect(body.metadata).to.have.property("embedding_model");
+    expect(body.metadata.embedding_model).to.eql(bru.getEnvVar("embedding_model"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Delete Uploaded File.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Delete Uploaded File.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete Uploaded File
+  type: http
+  seq: 9
+}
+
+delete {
+  url: {{baseUrl}}/v1/files/{{vs_file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200 or 204", function() {
+    expect([200, 204]).to.include(res.getStatus());
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Delete Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Delete Vector Store.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete Vector Store
+  type: http
+  seq: 8
+}
+
+delete {
+  url: {{baseUrl}}/v1/vector_stores/{{vector_store_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200 or 204", function() {
+    expect([200, 204]).to.include(res.getStatus());
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Get Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Get Vector Store.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Vector Store
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1/vector_stores/{{vector_store_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has matching vector store ID", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.eql(bru.getVar("vector_store_id"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/List Vector Stores.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/List Vector Stores.bru
@@ -1,0 +1,22 @@
+meta {
+  name: List Vector Stores
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/vector_stores
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has data array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Response with File Search.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Response with File Search.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Response with File Search
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "{{model}}",
+    "input": "What does the test upload file contain?",
+    "tools": [
+      {
+        "type": "file_search",
+        "vector_store_ids": ["{{vector_store_id}}"]
+      }
+    ],
+    "tool_choice": "required",
+    "temperature": 0
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response completed with output", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("status");
+    expect(body.status).to.eql("completed");
+    expect(body).to.have.property("output");
+    expect(body.output).to.be.an("array");
+    expect(body.output.length).to.be.greaterThan(0);
+  });
+  test("file_search tool was invoked", function() {
+    const output = res.getBody().output;
+    const call = output.find(item => item.type === "file_search_call");
+    expect(call).to.not.be.undefined;
+    expect(call.status).to.eql("completed");
+  });
+  test("file_search results contain uploaded file", function() {
+    const output = res.getBody().output;
+    const call = output.find(item => item.type === "file_search_call");
+    expect(call).to.have.property("results");
+    expect(call.results).to.be.an("array");
+    expect(call.results.length).to.be.greaterThan(0);
+    call.results.forEach(r => {
+      expect(r).to.have.property("file_id");
+      expect(r).to.have.property("text");
+      expect(r.text).to.be.a("string").and.not.empty;
+    });
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Search Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Search Vector Store.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Search Vector Store
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/v1/vector_stores/{{vector_store_id}}/search
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "query": "Bruno CRUD test",
+    "max_num_results": 3
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has search results", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Upload File for Vector Store.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Upload File for Vector Store.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Upload File for Vector Store
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/v1/files
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file: @file(test-upload.txt)
+  purpose: assistants
+}
+
+tests {
+  test("Status is 200 or 201", function() {
+    expect([200, 201]).to.include(res.getStatus());
+  });
+  test("File uploaded for vector store", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.be.a("string");
+    bru.setVar("vs_file_id", body.id);
+  });
+}

--- a/tests/functional/bruno/ogx-api/05-vector-stores/Verify Uploaded File Deleted.bru
+++ b/tests/functional/bruno/ogx-api/05-vector-stores/Verify Uploaded File Deleted.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Verify Uploaded File Deleted
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{baseUrl}}/v1/files/{{vs_file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Deleted file returns 404", function() {
+    expect(res.getStatus()).to.eql(404);
+  });
+}

--- a/tests/functional/bruno/ogx-api/06-responses/Create Response.bru
+++ b/tests/functional/bruno/ogx-api/06-responses/Create Response.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Create Response
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1/responses
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "model": "{{model}}",
+    "input": "Say hello in one word."
+  }
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has id and output", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.be.a("string");
+    expect(body.id).to.not.equal("");
+    expect(body).to.have.property("output");
+    expect(body.output).to.be.an("array");
+    bru.setVar("response_id", body.id);
+  });
+}

--- a/tests/functional/bruno/ogx-api/06-responses/Get Response.bru
+++ b/tests/functional/bruno/ogx-api/06-responses/Get Response.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Get Response
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/v1/responses/{{response_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has matching ID", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.eql(bru.getVar("response_id"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/06-responses/List Responses.bru
+++ b/tests/functional/bruno/ogx-api/06-responses/List Responses.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List Responses
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/v1/responses
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has data array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("data");
+    expect(body.data).to.be.an("array");
+    expect(body.data.length).to.be.lessThan(1000);
+  });
+}

--- a/tests/functional/bruno/ogx-api/07-file-processors/Delete Processed File.bru
+++ b/tests/functional/bruno/ogx-api/07-file-processors/Delete Processed File.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Delete Processed File
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/v1/files/{{fp_file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("Status is 200 or 204", function() {
+    expect([200, 204]).to.include(res.getStatus());
+  });
+}

--- a/tests/functional/bruno/ogx-api/07-file-processors/Process File Direct.bru
+++ b/tests/functional/bruno/ogx-api/07-file-processors/Process File Direct.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Process File Direct
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/v1alpha/file-processors/process
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file: @file(test-upload.txt)
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has chunks array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("chunks");
+    expect(body.chunks).to.be.an("array");
+    expect(body.chunks.length).to.be.greaterThan(0);
+  });
+  test("First chunk has content string", function() {
+    const body = res.getBody();
+    expect(body.chunks[0]).to.have.property("content");
+    expect(body.chunks[0].content).to.be.a("string");
+  });
+  test("Response has processing metadata", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("metadata");
+    expect(body.metadata).to.have.property("processor");
+  });
+}

--- a/tests/functional/bruno/ogx-api/07-file-processors/Process File by ID.bru
+++ b/tests/functional/bruno/ogx-api/07-file-processors/Process File by ID.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Process File by ID
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/v1alpha/file-processors/process
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file_id: {{fp_file_id}}
+}
+
+tests {
+  test("Status is 200", function() {
+    expect(res.getStatus()).to.eql(200);
+  });
+  test("Response has chunks array", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("chunks");
+    expect(body.chunks).to.be.an("array");
+    expect(body.chunks.length).to.be.greaterThan(0);
+  });
+  test("First chunk has content string", function() {
+    const body = res.getBody();
+    expect(body.chunks[0]).to.have.property("content");
+    expect(body.chunks[0].content).to.be.a("string");
+  });
+  test("Chunk metadata references the file ID", function() {
+    const body = res.getBody();
+    const meta = body.chunks[0].metadata || {};
+    expect(meta).to.have.property("file_id");
+    expect(meta.file_id).to.eql(bru.getVar("fp_file_id"));
+  });
+}

--- a/tests/functional/bruno/ogx-api/07-file-processors/Upload File for Processing.bru
+++ b/tests/functional/bruno/ogx-api/07-file-processors/Upload File for Processing.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Upload File for Processing
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/v1/files
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  file: @file(test-upload.txt)
+  purpose: assistants
+}
+
+tests {
+  test("Status is 200 or 201", function() {
+    expect([200, 201]).to.include(res.getStatus());
+  });
+  test("File created and ID saved", function() {
+    const body = res.getBody();
+    expect(body).to.have.property("id");
+    expect(body.id).to.be.a("string");
+    expect(body.id).to.not.equal("");
+    bru.setVar("fp_file_id", body.id);
+  });
+}

--- a/tests/functional/bruno/ogx-api/07-file-processors/Verify File Deleted.bru
+++ b/tests/functional/bruno/ogx-api/07-file-processors/Verify File Deleted.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Verify File Deleted
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{baseUrl}}/v1/files/{{fp_file_id}}
+  body: none
+  auth: inherit
+}
+
+tests {
+  test("File ID was set", function() {
+    const fileId = bru.getVar("fp_file_id");
+    expect(fileId).to.be.a("string").and.not.empty;
+  });
+  test("Deleted file returns 404", function() {
+    expect(res.getStatus()).to.eql(404);
+  });
+}

--- a/tests/functional/bruno/ogx-api/test-upload.txt
+++ b/tests/functional/bruno/ogx-api/test-upload.txt
@@ -1,0 +1,1 @@
+test upload content


### PR DESCRIPTION
## Summary

Add 31 Bruno CRUD tests across 7 API groups with 76 assertions:

- **01-admin:** Get Version, Get Health, List Providers, List Routes
- **02-models:** List Models (with item schema validation), Get Model (with pre-request input validation)
- **03-inference:** Create Chat Completion (with pre-request input validation), Create Text Completion, Create Embedding, List Chat Completions
- **04-files:** Create, Get, List, Delete File
- **05-vector-stores:** Create, Get, List, Delete, Upload, Attach, Search, Response with File Search, Delete Uploaded File (cleanup)
- **06-responses:** Create (non-empty ID check), Get, List (with pagination bound assertion)
- **07-file-processors:** Process Direct, Upload + Process by ID, Delete, Verify File Deleted (404 confirmation)

Strict assertions validate configured models, embedding models, and providers against server responses. Runtime IDs use `bru.setVar`/`getVar` (Bruno v4 compatible).

## Test plan

- [x] Pre-commit passes
- [x] Local ITS mode — 31/31 requests, 76/76 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional HTTP coverage for admin health/version, models, inference (text/chat completions and embeddings), files, vector stores (create/list/get/delete/search), and responses (create/list/get).
  * Added file-processing scenarios (upload, process direct/by ID) plus checks that processed and deleted files return not found.
  * Strengthened response assertions (e.g., non-empty arrays, expected fields, and status checks).
  * Updated shared upload fixture content and adjusted notebook JSON cell formatting.
  * Enhanced test runner setup to configure or auto-detect embedding dimension and updated the default embedding model accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->