### PR TITLE
ci(bedrock): add Bedrock live CI workflow for Responses tests

### DIFF
--- a/.github/workflows/responses-bedrock.yml
+++ b/.github/workflows/responses-bedrock.yml
@@ -1,0 +1,224 @@
+name: "Responses: Bedrock"
+
+on:
+  workflow_call:
+    inputs:
+      models:
+        description: 'Comma-separated model IDs to test (leave empty for defaults)'
+        required: false
+        type: string
+        default: ''
+      aws_region:
+        description: 'AWS region to use for Bedrock tests (leave empty for repo/default)'
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Image tag to test (default: latest)'
+        required: false
+        default: 'latest'
+        type: string
+      models:
+        description: 'Comma-separated model IDs to test (default: TEST_MODELS_BEDROCK)'
+        required: false
+        type: string
+      aws_region:
+        description: 'AWS region to use for Bedrock tests (default: repo/default)'
+        required: false
+        type: string
+
+env:
+  PROVIDER_NAME: bedrock
+  EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2
+  IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
+  IMAGE_TAG: ${{ inputs.image_tag || 'source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    outputs:
+      enabled: ${{ steps.check.outputs.enabled }}
+      models_json: ${{ steps.models.outputs.json }}
+      aws_region: ${{ steps.region.outputs.value }}
+    steps:
+      - name: Check Bedrock credentials
+        id: check
+        env:
+          AWS_BEDROCK_ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_BEDROCK_ROLE_ARN" ]; then
+            echo "::warning::AWS_BEDROCK_ROLE_ARN not configured, skipping tests"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve models
+        id: models
+        env:
+          INPUT_MODELS: ${{ inputs.models || vars.TEST_MODELS_BEDROCK }}
+        run: |
+          default='["bedrock/openai.gpt-oss-20b-1:0"]'
+          if [ -z "$INPUT_MODELS" ]; then
+            echo "json=$default" >> "$GITHUB_OUTPUT"
+          else
+            echo "json=$(printf '%s' "$INPUT_MODELS" | python3 -c 'import sys,json; print(json.dumps([m.strip() for m in sys.stdin.read().split(",") if m.strip()]))')" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve AWS region
+        id: region
+        env:
+          INPUT_REGION: ${{ inputs.aws_region || vars.AWS_BEDROCK_REGION || vars.AWS_DEFAULT_REGION }}
+        run: |
+          region="${INPUT_REGION:-us-east-2}"
+          echo "value=$region" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: check
+    if: needs.check.outputs.enabled == 'true'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(needs.check.outputs.models_json) }}
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    env:
+      AWS_DEFAULT_REGION: ${{ needs.check.outputs.aws_region }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: 3.12
+          enable-cache: false
+
+      - name: Validate Bedrock configuration
+        env:
+          AWS_BEDROCK_ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          missing=()
+          [ -z "$AWS_BEDROCK_ROLE_ARN" ] && missing+=("AWS_BEDROCK_ROLE_ARN")
+          [ -z "$AWS_DEFAULT_REGION" ] && missing+=("AWS_BEDROCK_REGION/AWS_DEFAULT_REGION")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::Missing required Bedrock config: %s\n' "$(IFS=,; echo "${missing[*]}")"
+            exit 1
+          fi
+
+      - name: Setup PostgreSQL
+        uses: ./.github/actions/setup-postgres
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          role-session-name: GitHubActions-Bedrock-${{ github.run_id }}
+
+      - name: Mint Bedrock bearer token
+        id: token
+        shell: bash
+        run: |
+          python3 -m pip install --disable-pip-version-check --quiet aws-bedrock-token-generator
+          token="$(python3 - <<'PY'
+          import os
+          from aws_bedrock_token_generator import provide_token
+
+          print(provide_token(region=os.environ["AWS_DEFAULT_REGION"]))
+          PY
+          )"
+
+          if [ -z "$token" ]; then
+            echo "::error::Failed to mint AWS Bedrock bearer token"
+            exit 1
+          fi
+
+          echo "::add-mask::$token"
+          echo "value=$token" >> "$GITHUB_OUTPUT"
+
+      - name: Setup server
+        uses: ./.github/actions/setup-server
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_tag: ${{ env.IMAGE_TAG }}
+          extra_env: |
+            ENABLE_BEDROCK=1
+            AWS_BEDROCK_BEARER_TOKEN=${{ steps.token.outputs.value }}
+            AWS_DEFAULT_REGION=${{ env.AWS_DEFAULT_REGION }}
+            TAVILY_SEARCH_API_KEY=${{ secrets.TAVILY_SEARCH_API_KEY }}
+            EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+            EMBEDDING_PROVIDER=sentence-transformers
+            EMBEDDING_PROVIDER_MODEL_ID=all-MiniLM-L6-v2
+
+      - name: Clone upstream tests
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/ogx-ai/ogx.git /tmp/ogx-tests
+          cd /tmp/ogx-tests
+          git fetch --depth 1 origin 9769a91c543e527389707e8a342339528d23c9f5 # v1.0.0
+          git checkout 9769a91c543e527389707e8a342339528d23c9f5
+
+          uv venv --clear
+          source .venv/bin/activate
+          uv pip install -e . ogx-client ollama pytest langchain-openai langgraph
+
+      - name: Derive short model name
+        id: model
+        env:
+          FULL_MODEL: ${{ matrix.model }}
+        run: |
+          short="${FULL_MODEL##*/}"
+          short="${short//:/-}"
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+
+      - name: Run responses tests
+        shell: bash
+        env:
+          MODEL: ${{ matrix.model }}
+          SHORT: ${{ steps.model.outputs.short }}
+        run: |
+          cd /tmp/ogx-tests
+          source .venv/bin/activate
+          mkdir -p /tmp/test-results
+
+          SKIP_TESTS="test_response_connector_resolution_mcp_tool"
+
+          python -m pytest -s -v tests/integration/responses/ \
+            -k "not ($SKIP_TESTS)" \
+            --stack-config=server:"$GITHUB_WORKSPACE/distribution/config.yaml" \
+            --text-model="$MODEL" \
+            --embedding-model="$EMBEDDING_MODEL" \
+            --inference-mode=live \
+            --junit-xml="/tmp/test-results/results_${PROVIDER_NAME}_${SHORT}.xml" \
+            || [ $? -eq 5 ]
+
+      - name: Publish test report
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: "${{ env.PROVIDER_NAME }}/${{ steps.model.outputs.short }}"
+          path: /tmp/test-results/*.xml
+          reporter: java-junit
+          fail-on-error: 'false'
+
+      - name: Upload artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: responses-${{ env.PROVIDER_NAME }}-${{ steps.model.outputs.short }}
+          path: /tmp/test-results/
+          retention-days: 90
+
+      - name: Cleanup
+        if: ${{ !cancelled() }}
+        run: |
+          for c in ogx postgres; do
+            docker rm -f "$c" 2>/dev/null || true
+          done

--- a/.github/workflows/responses-weekly.yml
+++ b/.github/workflows/responses-weekly.yml
@@ -29,6 +29,18 @@ on:
         description: 'vLLM MaaS models (comma-separated, leave empty for defaults)'
         type: string
         default: ''
+      run_bedrock:
+        description: 'Run Bedrock tests'
+        type: boolean
+        default: true
+      bedrock_models:
+        description: 'Bedrock models (comma-separated, leave empty for defaults)'
+        type: string
+        default: ''
+      bedrock_region:
+        description: 'Bedrock AWS region (leave empty for repo/default)'
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -61,12 +73,21 @@ jobs:
       models: ${{ inputs.vllm_maas_models }}
     secrets: inherit
 
+  # ── Bedrock ────────────────────────────────────────────────────
+  test-bedrock:
+    if: github.event_name == 'schedule' || inputs.run_bedrock != false
+    uses: ./.github/workflows/responses-bedrock.yml
+    with:
+      models: ${{ inputs.bedrock_models }}
+      aws_region: ${{ inputs.bedrock_region }}
+    secrets: inherit
+
   # ── Test Report & GitHub Pages ───────────────────────────────────
   report:
     name: Publish Test Report
     runs-on: ubuntu-24.04
     if: ${{ !cancelled() }}
-    needs: [test-openai, test-vertexai, test-vllm-maas]
+    needs: [test-openai, test-vertexai, test-vllm-maas, test-bedrock]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# What does this PR do?

Wire AWS Bedrock as a fourth provider in the weekly Responses test suite alongside OpenAI, Vertex AI, and vLLM MaaS.

Adds `responses-bedrock.yml` -- a reusable workflow that:
1. Validates `AWS_BEDROCK_ROLE_ARN` secret, skips gracefully when unconfigured
2. Assumes the IAM role via GitHub OIDC, mints a Bedrock bearer token
3. Starts the OGX server with Bedrock enabled and runs upstream `tests/integration/responses/`
4. Publishes results as GitHub check annotations and uploads JUnit artifacts

Ref: RHAIENG-1978

### Files changed

- `.github/workflows/responses-bedrock.yml` -- new reusable workflow for Bedrock live CI
- `.github/workflows/responses-weekly.yml` -- add `run_bedrock`/`bedrock_models`/`bedrock_region` inputs, wire `test-bedrock` job, add to report `needs`

## Test Plan

- [x] Workflow structure matches existing OpenAI/VertexAI/vLLM MaaS patterns (same IMAGE_TAG, clone SHA, action pins, exit-code-5 tolerance)
- [x] All third-party actions pinned to full SHA with version comments
- [x] Secrets masked with `::add-mask::`, OIDC permissions scoped to test job only
- [x] `actionlint` not available locally but structure manually verified against sibling workflows
- [ ] End-to-end validation pending AWS OIDC role ARN configuration
