### PR TITLE
fix(build): resolve branch refs in _resolve_ref_to_sha

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -70,7 +70,7 @@ def _resolve_ref_to_sha(repo_url: str, ref: str) -> str:
     For annotated tags, returns the dereferenced commit SHA.
     """
     result = subprocess.run(
-        ["git", "ls-remote", "--tags", repo_url, ref],
+        ["git", "ls-remote", "--tags", "--heads", repo_url, ref],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Summary
- Nightly scheduled builds fail at the "Regenerate distribution artifacts" step with `ValueError: Could not resolve ref 'main'`
- Root cause: `_resolve_ref_to_sha()` uses `git ls-remote --tags`, which only searches tags — branch names like `main` are not found
- Fix: add `--heads` so `git ls-remote` searches both tags and branches

## Related
- Companion fix for nightly builds: [#454](https://github.com/opendatahub-io/ogx-distribution/pull/454) (smoke test `IMAGE_TAG`)
- Failed run: [#28500753102](https://github.com/opendatahub-io/ogx-distribution/actions/runs/28500753102)

## Test plan
- [x] `OGX_VERSION=main python build/build.py` succeeds locally (previously raised `ValueError`)
- [x] Tags still resolve correctly (`git ls-remote --tags --heads` returns both)
- [x] `pre-commit run --all-files` passes
- [ ] Next nightly build passes the "Regenerate distribution artifacts" step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor build tooling update with no expected change to app behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->