### PR TITLE
ci: disable early-gate testing for odh-ogx-core

### DIFF
--- a/.tekton/odh-ogx-core-pull-request.yaml
+++ b/.tekton/odh-ogx-core-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     - 'odh-pr-{{revision}}'
   - name: pipeline-type
     value: pull-request
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-ogx-core-push.yaml
+++ b/.tekton/odh-ogx-core-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: Containerfile
   - name: path-context
     value: .
+  - name: enable-early-gate-testing
+    value: "false"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- Adds `enable-early-gate-testing: "false"` to both `.tekton/odh-ogx-core-pull-request.yaml` and `.tekton/odh-ogx-core-push.yaml`
- The shared `multi-arch-container-build` pipeline [defaults this to `"true"`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/pipeline/multi-arch-container-build.yaml#L100) for all components, but `ogx-distribution` is not listed in [`early-gate-config.yaml`](https://github.com/opendatahub-io/odh-konflux-central/blob/main/config/early-gate-config.yaml), causing a 403 on every pipeline run
- OGX will use Konflux ITS for container-level testing instead of early-gates ([discussion](https://redhat-internal.slack.com/archives/C0B72SWAT6U/p1779881200754309))

## Test plan

- [ ] Verify Konflux `odh-ogx-core-on-pull-request` pipeline passes without `trigger-early-gate-build` failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new pipeline setting to keep early gate testing turned off by default for pull request and push runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->