### PR TITLE
feat: support mounting secrets as files via _FILE env vars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,10 +51,6 @@ repos:
         pass_filenames: false
         require_serial: true
         always_run: true
-        additional_dependencies:
-          - uv>=0.9.0
-          - ruamel.yaml>=0.18.0
-          - pyyaml>=6.0.2
 
       - id: doc-gen
         name: Distribution Documentation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,10 @@ repos:
         pass_filenames: false
         require_serial: true
         always_run: true
+        additional_dependencies:
+          - uv>=0.9.0
+          - ruamel.yaml>=0.18.0
+          - pyyaml>=6.0.2
 
       - id: doc-gen
         name: Distribution Documentation

--- a/build/build.py
+++ b/build/build.py
@@ -31,6 +31,15 @@ _VERSION_PATTERN = re.compile(r"^[0-9a-zA-Z._+\-/]+$")
 
 OGX_GIT_REPO = "https://github.com/opendatahub-io/ogx.git"
 
+PINNED_DEPENDENCIES = ["milvus-lite>=3.0.0", "pymilvus!=2.6.10"]
+
+CONSTRAINTS_FILE = Path("distribution/constraints.txt")
+
+_SECRET_FIELD_WORDS = {"password", "secret", "token", "credential"}
+_SECRET_FIELD_SUBSTRINGS = {"api_key", "access_key"}
+_SECRET_FIELD_EXCLUDE_SUFFIXES = ("_file", "_path", "_url", "_dir")
+
+
 STRIPPED_PROVIDER_TYPES = {
     "inline::sentence-transformers",
     "inline::milvus",
@@ -452,6 +461,85 @@ def generate_containerfile(version: str):
     print(f"Successfully generated {output_path}")
 
 
+def _is_secret_field(field_name: str) -> bool:
+    """Heuristic: does this YAML config field name hold a secret value?"""
+    lower = field_name.lower()
+    if lower.endswith(_SECRET_FIELD_EXCLUDE_SUFFIXES):
+        return False
+    words = set(lower.split("_"))
+    if words & _SECRET_FIELD_WORDS:
+        return True
+    return any(sub in lower for sub in _SECRET_FIELD_SUBSTRINGS)
+
+
+def _extract_secret_env_vars_from_yaml(yaml_path: Path) -> set[str]:
+    """Walk build.yaml and return env var names referenced by secret fields."""
+    env_ref = re.compile(r"\$\{env\.([^:}]+):[=+]")
+    secrets: set[str] = set()
+
+    def _walk(node, parent_key=""):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                _walk(value, parent_key=key)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item, parent_key=parent_key)
+        elif isinstance(node, str):
+            if _is_secret_field(parent_key):
+                for match in env_ref.finditer(node):
+                    secrets.add(match.group(1))
+
+    with open(yaml_path) as f:
+        from yaml import safe_load
+
+        data = safe_load(f)
+    _walk(data)
+    return secrets
+
+
+def _extract_entrypoint_secrets(entrypoint_path: Path) -> set[str]:
+    """Extract the secret var names from the entrypoint.sh for-loop."""
+    text = entrypoint_path.read_text()
+    match = re.search(r"for _secret_var in\s*\\(.*?);\s*do", text, re.DOTALL)
+    if not match:
+        print(f"Error: could not find _secret_var loop in {entrypoint_path}")
+        sys.exit(1)
+    body = match.group(1).replace("\\", " ")
+    return {v for v in body.split() if v}
+
+
+def verify_file_secrets_sync():
+    """Verify that entrypoint.sh _FILE list matches secrets in build.yaml."""
+    yaml_path = Path("build/build.yaml")
+    entrypoint_path = Path("distribution/entrypoint.sh")
+
+    yaml_secrets = _extract_secret_env_vars_from_yaml(yaml_path)
+    entrypoint_secrets = _extract_entrypoint_secrets(entrypoint_path)
+
+    missing_from_entrypoint = yaml_secrets - entrypoint_secrets
+    extra_in_entrypoint = entrypoint_secrets - yaml_secrets
+
+    if missing_from_entrypoint or extra_in_entrypoint:
+        print(
+            "Error: distribution/entrypoint.sh _FILE secret list is out of sync "
+            "with build/build.yaml."
+        )
+        if missing_from_entrypoint:
+            print(f"  Add to entrypoint.sh:    {sorted(missing_from_entrypoint)}")
+        if extra_in_entrypoint:
+            print(f"  Remove from entrypoint.sh: {sorted(extra_in_entrypoint)}")
+        print(
+            "\nWhen adding a new provider with secret fields (api_key, password, "
+            "token, etc.) to build/build.yaml, also add the env var to the "
+            "_FILE resolution loop in distribution/entrypoint.sh."
+        )
+        sys.exit(1)
+
+    print(
+        f"Verified {len(yaml_secrets)} secret env vars have _FILE support in entrypoint.sh"
+    )
+
+
 def main():
     config = BuildConfig()
 
@@ -500,6 +588,9 @@ def main():
 
     print("Generating Containerfile...")
     generate_containerfile(config.ogx_version)
+
+    print("Verifying _FILE secret sync...")
+    verify_file_secrets_sync()
 
     print("Done!")
 

--- a/build/gen_distro_docs.py
+++ b/build/gen_distro_docs.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import yaml
 import re
+
+import yaml
 from pathlib import Path
 
 
@@ -182,6 +183,57 @@ def gen_distro_table(providers_data, runtime_provider_types=None):
     return "\n".join(table_lines)
 
 
+def extract_file_secret_vars():
+    """Extract the secret env var names from entrypoint.sh's _FILE resolution loop."""
+    entrypoint = REPO_ROOT / "distribution" / "entrypoint.sh"
+    text = entrypoint.read_text()
+    match = re.search(r"for _secret_var in\s*\\(.*?);\s*do", text, re.DOTALL)
+    if not match:
+        return []
+    body = match.group(1).replace("\\", " ")
+    return sorted(v for v in body.split() if v)
+
+
+def gen_file_secrets_section(secret_vars):
+    """Generate a markdown section documenting _FILE secret support."""
+    if not secret_vars:
+        return ""
+
+    var_list = "\n".join(f"- `{var}` → `{var}_FILE`" for var in secret_vars)
+
+    return f"""
+## Mounting Secrets as Files
+
+Instead of passing secrets directly as environment variables (which exposes them in
+`/proc/1/environ` and subprocess environments), you can mount them as files and
+point to them with `_FILE`-suffixed variables. At container startup, the entrypoint
+reads each file and populates the corresponding environment variable.
+
+For example, to inject `OPENAI_API_KEY` from a mounted Kubernetes Secret:
+
+```yaml
+env:
+  - name: OPENAI_API_KEY_FILE
+    value: /run/secrets/openai-api-key
+volumeMounts:
+  - name: openai-secret
+    mountPath: /run/secrets/openai-api-key
+    subPath: api-key
+    readOnly: true
+volumes:
+  - name: openai-secret
+    secret:
+      secretName: openai-credentials
+```
+
+Setting both the base variable and its `_FILE` variant is an error (mutually exclusive).
+
+### Supported variables
+
+{var_list}
+"""
+
+
 def gen_distro_docs():
     build_path = REPO_ROOT / "build" / "build.yaml"
     readme_path = REPO_ROOT / "distribution" / "README.md"
@@ -246,8 +298,13 @@ You can see an overview of the APIs and Providers the image ships with in the ta
             "definitions.\n"
         )
 
+        secret_vars = extract_file_secret_vars()
+        file_secrets_section = gen_file_secrets_section(secret_vars)
+
         with open(readme_path, "w") as readme_file:
-            readme_file.write(header + table_content + "\n" + dep_only_note)
+            readme_file.write(
+                header + table_content + "\n" + dep_only_note + file_secrets_section
+            )
 
         print(f"Successfully generated {readme_path}")
         print(

--- a/build/run.sh
+++ b/build/run.sh
@@ -32,4 +32,4 @@ exec "$runtime" run --rm \
     -v "$REPO_ROOT:/workspace:z" \
     -w /workspace \
     "$IMAGE" \
-    uv run --with ruamel.yaml --with pydantic-settings build/build.py
+    uv run --with ruamel.yaml --with pydantic-settings --with pyyaml build/build.py

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -41,3 +41,50 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | vector_io | remote::qdrant | No | ❌ | Set the `ENABLE_QDRANT` environment variable |
 
 \* **Dependency only** providers are not included in the default runtime `config.yaml` but their dependencies are pre-installed in the container image. To use them, pass a custom `config.yaml` at runtime that includes the provider definitions.
+
+## Mounting Secrets as Files
+
+Instead of passing secrets directly as environment variables (which exposes them in
+`/proc/1/environ` and subprocess environments), you can mount them as files and
+point to them with `_FILE`-suffixed variables. At container startup, the entrypoint
+reads each file and populates the corresponding environment variable.
+
+For example, to inject `OPENAI_API_KEY` from a mounted Kubernetes Secret:
+
+```yaml
+env:
+  - name: OPENAI_API_KEY_FILE
+    value: /run/secrets/openai-api-key
+volumeMounts:
+  - name: openai-secret
+    mountPath: /run/secrets/openai-api-key
+    subPath: api-key
+    readOnly: true
+volumes:
+  - name: openai-secret
+    secret:
+      secretName: openai-credentials
+```
+
+Setting both the base variable and its `_FILE` variant is an error (mutually exclusive).
+
+### Supported variables
+
+- `ANTHROPIC_API_KEY` → `ANTHROPIC_API_KEY_FILE`
+- `AWS_ACCESS_KEY_ID` → `AWS_ACCESS_KEY_ID_FILE`
+- `AWS_BEDROCK_BEARER_TOKEN` → `AWS_BEDROCK_BEARER_TOKEN_FILE`
+- `AWS_SECRET_ACCESS_KEY` → `AWS_SECRET_ACCESS_KEY_FILE`
+- `AZURE_API_KEY` → `AZURE_API_KEY_FILE`
+- `BRAVE_SEARCH_API_KEY` → `BRAVE_SEARCH_API_KEY_FILE`
+- `DOCLING_SERVE_API_KEY` → `DOCLING_SERVE_API_KEY_FILE`
+- `GEMINI_ACCESS_TOKEN` → `GEMINI_ACCESS_TOKEN_FILE`
+- `GEMINI_API_KEY` → `GEMINI_API_KEY_FILE`
+- `MILVUS_TOKEN` → `MILVUS_TOKEN_FILE`
+- `OPENAI_API_KEY` → `OPENAI_API_KEY_FILE`
+- `PGVECTOR_PASSWORD` → `PGVECTOR_PASSWORD_FILE`
+- `POSTGRES_PASSWORD` → `POSTGRES_PASSWORD_FILE`
+- `QDRANT_API_KEY` → `QDRANT_API_KEY_FILE`
+- `TAVILY_SEARCH_API_KEY` → `TAVILY_SEARCH_API_KEY_FILE`
+- `VLLM_API_TOKEN` → `VLLM_API_TOKEN_FILE`
+- `VLLM_EMBEDDING_API_TOKEN` → `VLLM_EMBEDDING_API_TOKEN_FILE`
+- `WATSONX_API_KEY` → `WATSONX_API_KEY_FILE`

--- a/distribution/entrypoint.sh
+++ b/distribution/entrypoint.sh
@@ -1,6 +1,61 @@
 #!/bin/sh
 set -e
 
+# Resolve _FILE variants for secret environment variables.
+#
+# For each secret variable (e.g. OPENAI_API_KEY), if the corresponding
+# _FILE variant (OPENAI_API_KEY_FILE) is set, read the file contents
+# into the base variable. This lets Kubernetes operators mount secrets
+# as files instead of injecting them via env vars, avoiding exposure
+# through /proc/1/environ and subprocess environments.
+resolve_file_secret() {
+  _rfs_var="$1"
+  _rfs_file_var="${_rfs_var}_FILE"
+  eval "_rfs_file_val=\${${_rfs_file_var}:-}"
+  eval "_rfs_var_val=\${${_rfs_var}:-}"
+
+  if [ -n "$_rfs_file_val" ] && [ -n "$_rfs_var_val" ]; then
+    printf 'Error: both %s and %s are set (mutually exclusive)\n' \
+      "$_rfs_var" "$_rfs_file_var" >&2
+    exit 1
+  fi
+
+  if [ -n "$_rfs_file_val" ]; then
+    if [ ! -f "$_rfs_file_val" ]; then
+      printf 'Error: %s references %s, which is not a regular file\n' \
+        "$_rfs_file_var" "$_rfs_file_val" >&2
+      exit 1
+    fi
+    _rfs_content="$(cat "$_rfs_file_val")"
+    eval "export ${_rfs_var}=\$_rfs_content"
+    unset "$_rfs_file_var"
+  fi
+}
+
+for _secret_var in \
+    ANTHROPIC_API_KEY \
+    AWS_ACCESS_KEY_ID \
+    AWS_BEDROCK_BEARER_TOKEN \
+    AWS_SECRET_ACCESS_KEY \
+    AZURE_API_KEY \
+    BRAVE_SEARCH_API_KEY \
+    DOCLING_SERVE_API_KEY \
+    GEMINI_ACCESS_TOKEN \
+    GEMINI_API_KEY \
+    MILVUS_TOKEN \
+    OPENAI_API_KEY \
+    PGVECTOR_PASSWORD \
+    POSTGRES_PASSWORD \
+    QDRANT_API_KEY \
+    TAVILY_SEARCH_API_KEY \
+    VLLM_API_TOKEN \
+    VLLM_EMBEDDING_API_TOKEN \
+    WATSONX_API_KEY \
+; do
+  resolve_file_secret "$_secret_var"
+done
+unset _secret_var
+
 # Resolve config path
 if [ -n "$RUN_CONFIG_PATH" ] && [ -f "$RUN_CONFIG_PATH" ]; then
   CONFIG="$RUN_CONFIG_PATH"

--- a/distribution/requirements-lock.txt
+++ b/distribution/requirements-lock.txt
@@ -135,13 +135,13 @@ beautifulsoup4==4.15.0 \
     #   docling-slim
     #   markdownify
     #   markitdown
-boto3==1.43.46 \
-    --hash=sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96 \
-    --hash=sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c
+boto3==1.43.47 \
+    --hash=sha256:09a8ce4abab4391bf08315e2dcc449b4b33e97ce7654ee9398d9fe4ef73a33da \
+    --hash=sha256:aef0cccd5bc4a443fb3e64fada023f7b5b9da36864cb4255b68cf93067476676
     # via -r /tmp/requirements.txt
-botocore==1.43.46 \
-    --hash=sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533 \
-    --hash=sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60
+botocore==1.43.47 \
+    --hash=sha256:4d16559a3a1866fa7b9e651dd1422c1a033497e069f8a73cae5eebafe70ff39c \
+    --hash=sha256:9e04d8da7f9cff8a911b14284829f78b74e1ce785444833199837decb5ecc17a
     # via
     #   boto3
     #   s3transfer

--- a/tests/test_file_secrets.sh
+++ b/tests/test_file_secrets.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Tests for _FILE secret resolution in entrypoint.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="$SCRIPT_DIR/../distribution/entrypoint.sh"
+FAILURES=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+setup_tmpdir() {
+  TMPDIR_TEST="$(mktemp -d)"
+}
+
+teardown_tmpdir() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+# Source just the resolve_file_secret function from entrypoint.sh.
+# We extract the function and the for-loop so we can test them in isolation
+# without exec-ing ogx.
+source_resolve_function() {
+  eval "$(sed -n '/^resolve_file_secret()/,/^}$/p' "$ENTRYPOINT")"
+}
+
+echo "=== _FILE secret resolution tests ==="
+
+# Test 1: _FILE populates the base variable
+echo "--- Test: _FILE env var populates base variable ---"
+(
+  setup_tmpdir
+  source_resolve_function
+  echo -n "s3cret-key" > "$TMPDIR_TEST/api_key"
+  unset OPENAI_API_KEY 2>/dev/null || true
+  export OPENAI_API_KEY_FILE="$TMPDIR_TEST/api_key"
+  resolve_file_secret OPENAI_API_KEY
+  if [ "$OPENAI_API_KEY" = "s3cret-key" ]; then
+    pass "base variable populated from file"
+  else
+    fail "expected 's3cret-key', got '$OPENAI_API_KEY'"
+  fi
+  teardown_tmpdir
+) || fail "subshell exited with error"
+
+# Test 2: _FILE variable is unset after resolution
+echo "--- Test: _FILE variable is unset after resolution ---"
+(
+  setup_tmpdir
+  source_resolve_function
+  echo -n "tok" > "$TMPDIR_TEST/token"
+  unset VLLM_API_TOKEN 2>/dev/null || true
+  export VLLM_API_TOKEN_FILE="$TMPDIR_TEST/token"
+  resolve_file_secret VLLM_API_TOKEN
+  if [ -z "${VLLM_API_TOKEN_FILE:-}" ]; then
+    pass "_FILE variable unset"
+  else
+    fail "_FILE variable still set: '$VLLM_API_TOKEN_FILE'"
+  fi
+  teardown_tmpdir
+) || fail "subshell exited with error"
+
+# Test 3: base variable preserved when no _FILE is set
+echo "--- Test: base variable unchanged when _FILE is absent ---"
+(
+  source_resolve_function
+  export POSTGRES_PASSWORD="inline-pass"
+  unset POSTGRES_PASSWORD_FILE 2>/dev/null || true
+  resolve_file_secret POSTGRES_PASSWORD
+  if [ "$POSTGRES_PASSWORD" = "inline-pass" ]; then
+    pass "base variable unchanged"
+  else
+    fail "expected 'inline-pass', got '$POSTGRES_PASSWORD'"
+  fi
+) || fail "subshell exited with error"
+
+# Test 4: error when both base and _FILE are set
+echo "--- Test: mutual exclusion error ---"
+(
+  setup_tmpdir
+  source_resolve_function
+  echo -n "file-val" > "$TMPDIR_TEST/key"
+  export AZURE_API_KEY="env-val"
+  export AZURE_API_KEY_FILE="$TMPDIR_TEST/key"
+  if output=$(resolve_file_secret AZURE_API_KEY 2>&1); then
+    fail "should have exited with error"
+  else
+    if echo "$output" | grep -q "mutually exclusive"; then
+      pass "mutual exclusion detected"
+    else
+      fail "unexpected error: $output"
+    fi
+  fi
+  teardown_tmpdir
+) || pass "mutual exclusion detected (exit)"
+
+# Test 5: error when _FILE references a missing file
+echo "--- Test: missing file error ---"
+(
+  source_resolve_function
+  unset MILVUS_TOKEN 2>/dev/null || true
+  export MILVUS_TOKEN_FILE="/nonexistent/path/secret"
+  if output=$(resolve_file_secret MILVUS_TOKEN 2>&1); then
+    fail "should have exited with error"
+  else
+    if echo "$output" | grep -q "not a regular file"; then
+      pass "missing file detected"
+    else
+      fail "unexpected error: $output"
+    fi
+  fi
+) || pass "missing file detected (exit)"
+
+# Test 6: trailing newlines in file are stripped (standard $(cat) behavior)
+echo "--- Test: trailing newlines stripped ---"
+(
+  setup_tmpdir
+  source_resolve_function
+  printf 'my-api-key\n\n' > "$TMPDIR_TEST/key_with_newlines"
+  unset BRAVE_SEARCH_API_KEY 2>/dev/null || true
+  export BRAVE_SEARCH_API_KEY_FILE="$TMPDIR_TEST/key_with_newlines"
+  resolve_file_secret BRAVE_SEARCH_API_KEY
+  if [ "$BRAVE_SEARCH_API_KEY" = "my-api-key" ]; then
+    pass "trailing newlines stripped"
+  else
+    fail "expected 'my-api-key', got '$BRAVE_SEARCH_API_KEY'"
+  fi
+  teardown_tmpdir
+) || fail "subshell exited with error"
+
+# Test 7: file content with special characters
+echo "--- Test: special characters preserved ---"
+(
+  setup_tmpdir
+  source_resolve_function
+  # shellcheck disable=SC2016
+  echo -n 'p@$$w0rd!#%^&*()' > "$TMPDIR_TEST/special"
+  unset PGVECTOR_PASSWORD 2>/dev/null || true
+  export PGVECTOR_PASSWORD_FILE="$TMPDIR_TEST/special"
+  resolve_file_secret PGVECTOR_PASSWORD
+  # shellcheck disable=SC2016
+  if [ "$PGVECTOR_PASSWORD" = 'p@$$w0rd!#%^&*()' ]; then
+    pass "special characters preserved"
+  else
+    fail "expected 'p@\$\$w0rd!#%^&*()', got '$PGVECTOR_PASSWORD'"
+  fi
+  teardown_tmpdir
+) || fail "subshell exited with error"
+
+# Test 8: noop when neither base nor _FILE is set
+echo "--- Test: noop when neither is set ---"
+(
+  source_resolve_function
+  unset WATSONX_API_KEY 2>/dev/null || true
+  unset WATSONX_API_KEY_FILE 2>/dev/null || true
+  resolve_file_secret WATSONX_API_KEY
+  if [ -z "${WATSONX_API_KEY:-}" ]; then
+    pass "noop when neither is set"
+  else
+    fail "variable should be unset, got '$WATSONX_API_KEY'"
+  fi
+) || fail "subshell exited with error"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All tests passed!"
+  exit 0
+else
+  echo "$FAILURES test(s) failed!"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `_FILE` variant support for 18 secret env vars in the container entrypoint — when e.g. `OPENAI_API_KEY_FILE` points to a mounted file, its contents are read into `OPENAI_API_KEY` at startup, avoiding exposure via `/proc/1/environ` and subprocess environments
- Add a pre-commit sync check in `build/build.py` that auto-detects secret fields in `build/build.yaml` by field name heuristic and fails the build if any are missing from the entrypoint's `_FILE` resolution list
- Add auto-generated documentation in `distribution/README.md` with supported variable list and Kubernetes Pod spec example

## Test plan

- [ ] `shellcheck distribution/entrypoint.sh` passes
- [ ] `bash tests/test_file_secrets.sh` — 8 unit tests covering: file→env resolution, `_FILE` cleanup, base variable preservation, mutual exclusion error, missing file error, trailing newline stripping, special characters, noop
- [ ] `pre-commit run --all-files` passes (sync check + docs regeneration)
- [ ] Verify sync check: temporarily add a secret field to `build/build.yaml` without updating `entrypoint.sh` → `build/build.py` errors with a message naming the missing var

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing container secrets through mounted files using `_FILE` environment variables.
  * Resolves `_FILE` values at startup, exports the secret content, and unsets the `_FILE` variables.
  * Validates and fails on conflicting base and `_FILE` values, plus missing or non-regular files.
* **Documentation**
  * Added a “Mounting Secrets as Files” section with Kubernetes examples and supported variable mappings.
* **Tests**
  * Added `entrypoint.sh` `_FILE` secret resolution tests covering success, error cases, and file content handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->