### PR TITLE
fix(ci): run lockfile generation inside container for OpenSSL compat

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -24,14 +24,8 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          python-version: 3.12
-          enable-cache: false
-
       - name: Regenerate lockfiles
-        run: uv run build/gen_lockfile.py
+        run: ./build/run_gen_lockfile.sh
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Summary

- Use `run_gen_lockfile.sh` instead of running `gen_lockfile.py` directly on the runner
- Removes the now-unnecessary `setup-uv` step (uv is provided by the container image)

The nightly `update-lockfiles` workflow fails because the RHAI index provides a `cryptography` package built against OpenSSL 3.2+, which is not available on GitHub Actions runners (Ubuntu ships OpenSSL 3.0.x). The `run_gen_lockfile.sh` wrapper runs `gen_lockfile.py` inside the UBI9-based `odh-midstream-python-base-3-12` container image, which has OpenSSL 3.5.

## Test plan

- [ ] Manually trigger the `update-lockfiles` workflow and verify both lockfiles generate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency lockfile refresh process.
  * Existing pull request handling and failure notifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->