### PR TITLE
fix(ci): run gen_lockfile.py in container for OpenSSL compat

### DIFF
--- a/.github/actions/regenerate-artifacts/action.yml
+++ b/.github/actions/regenerate-artifacts/action.yml
@@ -24,5 +24,5 @@ runs:
           export OGX_VERSION="$OGX_VERSION_OVERRIDE"
         fi
         uv run build/gen_config.py
-        uv run build/gen_lockfile.py
+        ./build/run_gen_lockfile.sh
         uv run build/gen_containerfile.py


### PR DESCRIPTION
## Summary

- Run `gen_lockfile.py` inside a UBI9 container via `run_gen_lockfile.sh` in the `regenerate-artifacts` action, matching the approach already used by the `update-lockfiles` workflow (#510)

The nightly schedule builds (`redhat-distro-container.yml`) have been failing since late June at the "Regenerate distribution artifacts" step with:

```
ImportError: libcrypto.so.3: version `OPENSSL_3.2.0' not found
(required by cryptography/hazmat/bindings/_rust.abi3.so)
```

The RHAI Python index provides a `cryptography` package built against OpenSSL 3.2+, but GitHub Actions runners (Ubuntu 24.04) ship OpenSSL 3.0.x. PR #510 fixed this same issue for the `update-lockfiles` workflow by running `gen_lockfile.py` inside the `odh-midstream-python-base-3-12` container (which has OpenSSL 3.5), but the `regenerate-artifacts` action was not updated.

This is one of the root causes behind RHOAIENG-70548 (OGX build failures blocking downstream Konflux snapshots and Crimson E2E tests).

## Verification

Tested via `workflow_dispatch` on a fork ([run](https://github.com/EleanorWho/ogx-distribution/actions/runs/29821075660)): the OpenSSL error is resolved and the midstream lockfile (`requirements-lock.txt`) generates successfully. The downstream lockfile (`requirements-lock-konflux.txt`) fails due to a separate issue — `opentelemetry-instrumentation-structlog==0.65b0` is missing from the RHAI index — which is unrelated to this change.

## Test plan

- [x] `workflow_dispatch` on fork confirms OpenSSL error is fixed
- [ ] Midstream lockfile generates successfully (verified in fork run)
- [ ] Nightly schedule build passes the "Regenerate distribution artifacts" step after merge