### PR TITLE
fix(ci): migrate MaaS config to LiteMaaS vars and single API key

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Validate provider credentials
         env:
-          _MAAS_VLLM_URL: ${{ secrets.MAAS_VLLM_URL }}
+          _MAAS_VLLM_URL: ${{ vars.LITEMAAS_URL }}
         run: |
           # Fork/Dependabot PRs: secrets are unavailable
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -205,10 +205,12 @@ jobs:
 
       - name: Configure MaaS vLLM endpoints
         env:
-          _MAAS_VLLM_URL: ${{ secrets.MAAS_VLLM_URL }}
-          _MAAS_VLLM_API_TOKEN: ${{ secrets.MAAS_VLLM_API_TOKEN }}
-          _MAAS_EMBEDDING_URL: ${{ secrets.MAAS_EMBEDDING_URL }}
-          _MAAS_EMBEDDING_API_TOKEN: ${{ secrets.MAAS_EMBEDDING_API_TOKEN }}
+          _MAAS_VLLM_URL: ${{ vars.LITEMAAS_URL }}
+          _MAAS_VLLM_API_TOKEN: ${{ secrets.LITEMAAS_API_KEY }}
+          _MAAS_EMBEDDING_URL: ${{ vars.LITEMAAS_URL }}
+          _MAAS_EMBEDDING_API_TOKEN: ${{ secrets.LITEMAAS_API_KEY }}
+          _MAAS_INFERENCE_MODEL: ${{ vars.LITEMAAS_INFERENCE_MODEL }}
+          _MAAS_EMBEDDING_MODEL: ${{ vars.LITEMAAS_EMBEDDING_MODEL }}
         run: |
           if [ -z "$_MAAS_VLLM_URL" ]; then
             echo "MaaS vLLM URL not configured, skipping"
@@ -218,12 +220,12 @@ jobs:
           {
             echo "VLLM_URL=$_MAAS_VLLM_URL"
             echo "VLLM_API_TOKEN=$_MAAS_VLLM_API_TOKEN"
-            echo "VLLM_INFERENCE_MODEL=vllm-inference/llama-3-2-3b"
+            echo "VLLM_INFERENCE_MODEL=vllm-inference/$_MAAS_INFERENCE_MODEL"
             echo "VLLM_EMBEDDING_URL=$_MAAS_EMBEDDING_URL"
             echo "VLLM_EMBEDDING_API_TOKEN=$_MAAS_EMBEDDING_API_TOKEN"
-            echo "EMBEDDING_MODEL=vllm-embedding/nomic-embed-text-v1-5"
+            echo "EMBEDDING_MODEL=vllm-embedding/$_MAAS_EMBEDDING_MODEL"
             echo "EMBEDDING_PROVIDER=vllm-embedding"
-            echo "EMBEDDING_PROVIDER_MODEL_ID=nomic-embed-text-v1-5"
+            echo "EMBEDDING_PROVIDER_MODEL_ID=$_MAAS_EMBEDDING_MODEL"
             echo "USING_MAAS=true"
           } >> "$GITHUB_ENV"
 

--- a/.github/workflows/responses-vllm-maas.yml
+++ b/.github/workflows/responses-vllm-maas.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   PROVIDER_NAME: vllm-maas
-  EMBEDDING_MODEL: vllm-embedding/Nomic-embed-text-v2-moe
+  EMBEDDING_MODEL: vllm-embedding/${{ vars.LITEMAAS_EMBEDDING_MODEL }}
   IMAGE_NAME: quay.io/opendatahub/odh-ogx-core
   IMAGE_TAG: ${{ inputs.image_tag || 'source-b5c18de28794baaf537b2683271a5043ccd42426-6515a120edf38a477a55b037e745752f2535661c' }}
 
@@ -36,8 +36,8 @@ jobs:
       - name: Check MaaS credentials
         id: check
         env:
-          MAAS_VLLM_URL: ${{ secrets.MAAS_VLLM_URL }}
-          MAAS_VLLM_API_TOKEN: ${{ secrets.MAAS_VLLM_API_TOKEN }}
+          MAAS_VLLM_URL: ${{ vars.LITEMAAS_URL }}
+          MAAS_VLLM_API_TOKEN: ${{ secrets.LITEMAAS_API_KEY }}
         run: |
           if [ -z "$MAAS_VLLM_URL" ] || [ -z "$MAAS_VLLM_API_TOKEN" ]; then
             echo "::warning::MaaS vLLM credentials not configured, skipping tests"
@@ -87,14 +87,14 @@ jobs:
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: ${{ env.IMAGE_TAG }}
           extra_env: |
-            VLLM_URL=${{ secrets.MAAS_VLLM_URL }}
-            VLLM_API_TOKEN=${{ secrets.MAAS_VLLM_API_TOKEN }}
-            VLLM_EMBEDDING_URL=${{ secrets.MAAS_EMBEDDING_URL }}
-            VLLM_EMBEDDING_API_TOKEN=${{ secrets.MAAS_EMBEDDING_API_TOKEN }}
+            VLLM_URL=${{ vars.LITEMAAS_URL }}
+            VLLM_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
+            VLLM_EMBEDDING_URL=${{ vars.LITEMAAS_URL }}
+            VLLM_EMBEDDING_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
             TAVILY_SEARCH_API_KEY=${{ secrets.TAVILY_SEARCH_API_KEY }}
-            EMBEDDING_MODEL=vllm-embedding/Nomic-embed-text-v2-moe
+            EMBEDDING_MODEL=${{ env.EMBEDDING_MODEL }}
             EMBEDDING_PROVIDER=vllm-embedding
-            EMBEDDING_PROVIDER_MODEL_ID=Nomic-embed-text-v2-moe
+            EMBEDDING_PROVIDER_MODEL_ID=${{ vars.LITEMAAS_EMBEDDING_MODEL }}
 
       - name: Clone upstream tests
         shell: bash
@@ -149,8 +149,8 @@ jobs:
       - name: Scrub secrets from test results
         if: ${{ !cancelled() }}
         env:
-          VLLM_API_TOKEN: ${{ secrets.MAAS_VLLM_API_TOKEN }}
-          VLLM_EMBEDDING_API_TOKEN: ${{ secrets.MAAS_EMBEDDING_API_TOKEN }}
+          VLLM_API_TOKEN: ${{ secrets.LITEMAAS_API_KEY }}
+          VLLM_EMBEDDING_API_TOKEN: ${{ secrets.LITEMAAS_API_KEY }}
           TAVILY_SEARCH_API_KEY: ${{ secrets.TAVILY_SEARCH_API_KEY }}
         run: |
           ./tests/scrub_secrets.sh '/tmp/test-results/*' \

--- a/.github/workflows/test-pr-in-showroom.yml
+++ b/.github/workflows/test-pr-in-showroom.yml
@@ -159,19 +159,22 @@ jobs:
 
       - name: Setup CI environment
         id: setup
-        uses: derekhiggins/llama-stack-showroom@f32973c9b7389b14d1988b55abfe74dd98c2432f  # main as of 2026-06-05
+        uses: opendatahub-io/ogx-showroom@5cc2fe338d2bbfe12159891bb3f0ab41469e389a  # main as of 2026-07-24 (includes #56 model env vars)
         with:
           catalog_image: ${{ inputs.catalog_image }}
-          llama_stack_image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-operator/ogx-test:${{ needs.verify-and-build.outputs.tag }}"
+          ogx_image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-operator/ogx-test:${{ needs.verify-and-build.outputs.tag }}"
           operator_image: ${{ inputs.operator_image }}
           oc_server: ${{ secrets.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           env: |
             SHOWROOM_PULL_SECRET=${{ secrets.SHOWROOM_PULL_SECRET }}
-            SHOWROOM_VLLM_URL=https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1
-            SHOWROOM_VLLM_API_TOKEN=${{ secrets.SHOWROOM_VLLM_API_TOKEN }}
-            SHOWROOM_VLLM_EMBEDDING_URL=https://nomic-embed-text-v1-5-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1
-            SHOWROOM_VLLM_EMBEDDING_API_TOKEN=${{ secrets.SHOWROOM_VLLM_EMBEDDING_API_TOKEN }}
+            SHOWROOM_VLLM_URL=${{ vars.LITEMAAS_URL }}
+            SHOWROOM_VLLM_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
+            SHOWROOM_INFERENCE_MODEL=${{ vars.LITEMAAS_INFERENCE_MODEL }}
+            SHOWROOM_VLLM_EMBEDDING_URL=${{ vars.LITEMAAS_URL }}
+            SHOWROOM_VLLM_EMBEDDING_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
+            SHOWROOM_EMBEDDING_MODEL=${{ vars.LITEMAAS_EMBEDDING_MODEL }}
+            SHOWROOM_EMBEDDING_PROVIDER_MODEL_ID=${{ vars.LITEMAAS_EMBEDDING_MODEL }}
             SHOWROOM_OPENAI_API_KEY=${{ secrets.SHOWROOM_OPENAI_API_KEY }}
 
       - name: Push image to OpenShift registry

--- a/.github/workflows/test-upstream-in-showroom.yml
+++ b/.github/workflows/test-upstream-in-showroom.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup CI environment
         id: setup
-        uses: opendatahub-io/ogx-showroom@a3a6adc939c464c9acc7f224482f5dacbf83558d  # main as of 2026-06-09
+        uses: opendatahub-io/ogx-showroom@5cc2fe338d2bbfe12159891bb3f0ab41469e389a  # main as of 2026-07-24 (includes #56 model env vars)
         with:
           catalog_image: ${{ inputs.catalog_image }}
           ogx_image: "image-registry.openshift-image-registry.svc:5000/redhat-ods-operator/ogx-test:${{ steps.build.outputs.tag }}"
@@ -61,10 +61,13 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           env: |
             SHOWROOM_PULL_SECRET=${{ secrets.SHOWROOM_PULL_SECRET }}
-            SHOWROOM_VLLM_URL=https://llama-3-2-3b-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1
-            SHOWROOM_VLLM_API_TOKEN=${{ secrets.SHOWROOM_VLLM_API_TOKEN }}
-            SHOWROOM_VLLM_EMBEDDING_URL=https://nomic-embed-text-v1-5-maas-apicast-production.apps.prod.rhoai.rh-aiservices-bu.com:443/v1
-            SHOWROOM_VLLM_EMBEDDING_API_TOKEN=${{ secrets.SHOWROOM_VLLM_EMBEDDING_API_TOKEN }}
+            SHOWROOM_VLLM_URL=${{ vars.LITEMAAS_URL }}
+            SHOWROOM_VLLM_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
+            SHOWROOM_INFERENCE_MODEL=${{ vars.LITEMAAS_INFERENCE_MODEL }}
+            SHOWROOM_VLLM_EMBEDDING_URL=${{ vars.LITEMAAS_URL }}
+            SHOWROOM_VLLM_EMBEDDING_API_TOKEN=${{ secrets.LITEMAAS_API_KEY }}
+            SHOWROOM_EMBEDDING_MODEL=${{ vars.LITEMAAS_EMBEDDING_MODEL }}
+            SHOWROOM_EMBEDDING_PROVIDER_MODEL_ID=${{ vars.LITEMAAS_EMBEDDING_MODEL }}
             SHOWROOM_OPENAI_API_KEY=${{ secrets.SHOWROOM_OPENAI_API_KEY }}
 
       - name: Push image to OpenShift registry

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ An orchestrator workflow (`responses-weekly.yml` / "Responses: Test Report") run
 |----------|--------------------|-----------------|----------|
 | OpenAI | gpt-4.1-nano | text-embedding-3-small | `responses-openai.yml` |
 | Vertex AI | gemini-2.5-flash | gemini-embedding-2 | `responses-vertexai.yml` |
-| vLLM MaaS | llama-3-2-3b | nomic-embed-text-v1-5 | `responses-vllm-maas.yml` |
+| vLLM MaaS | Qwen3.6-35B-A3B | Nomic-embed-text-v2-moe | `responses-vllm-maas.yml` |
 
 ### How it works
 
@@ -121,7 +121,7 @@ To override models: pass comma-separated model IDs via the `models` input when d
 |----------|---------|
 | OpenAI | `OPENAI_API_KEY` |
 | Vertex AI | `VERTEX_AI_PROJECT`, `VERTEX_AI_LOCATION` (default: `global`), `GCP_WORKLOAD_IDENTITY_PROVIDER` |
-| vLLM MaaS | `MAAS_VLLM_URL`, `MAAS_VLLM_API_TOKEN`, `MAAS_EMBEDDING_URL`, `MAAS_EMBEDDING_API_TOKEN` |
+| vLLM MaaS | `LITEMAAS_API_KEY` (secret), `LITEMAAS_URL` (var), `LITEMAAS_INFERENCE_MODEL` (var), `LITEMAAS_EMBEDDING_MODEL` (var) |
 
 ## ARM64 Support
 


### PR DESCRIPTION
## Summary

- Replace hardcoded per-model MaaS URLs in showroom workflows with `vars.LITEMAAS_URL`
- Replace old `secrets.MAAS_VLLM_URL` / `secrets.MAAS_VLLM_API_TOKEN` / `secrets.MAAS_EMBEDDING_URL` / `secrets.MAAS_EMBEDDING_API_TOKEN` with a single `vars.LITEMAAS_URL` + `secrets.LITEMAAS_API_KEY`
- Extract hardcoded model names (`llama-3-2-3b`, `nomic-embed-text-v1-5`) to `vars.LITEMAAS_INFERENCE_MODEL` / `vars.LITEMAAS_EMBEDDING_MODEL`
- Update README with new model names and required secrets/vars

## Required repo configuration

Before merging, create these in **Settings → Secrets and variables → Actions**:

| Name | Type | Value |
|------|------|-------|
| `LITEMAAS_URL` | Variable | `https://litemaas.rhoai.rh-aiservices-bu.com/v1` |
| `LITEMAAS_INFERENCE_MODEL` | Variable | `Qwen3.6-35B-A3B` |
| `LITEMAAS_EMBEDDING_MODEL` | Variable | `Nomic-embed-text-v2-moe` |
| `LITEMAAS_API_KEY` | Secret | *(LiteMaaS API key for `odh-llama-stack-distribution-ci`)* |

Old secrets (`MAAS_VLLM_URL`, `MAAS_VLLM_API_TOKEN`, `MAAS_EMBEDDING_URL`, `MAAS_EMBEDDING_API_TOKEN`, `SHOWROOM_VLLM_API_TOKEN`, `SHOWROOM_VLLM_EMBEDDING_API_TOKEN`) can be removed after merge.

## Context

MaaS endpoint was rotated to LiteMaaS (LiteLLM proxy) on 2026-07-20. With LiteLLM, all models (inference + embedding) share a single URL and API key. The old per-model endpoints are being decommissioned; the new generic `litemaas.rhoai.rh-aiservices-bu.com` URL is permanent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the provider matrix and required-secrets tables for vLLM MaaS to use LITEMAAS configuration keys, including the default embedding model.
* **Tests**
  * Updated CI workflows to use centralized LITEMAAS endpoints, API keys, and configurable inference and embedding models.
  * Improved test log redaction for LITEMAAS API tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related

Companion PR for showroom demo scripts: https://github.com/opendatahub-io/ogx-showroom/pull/56