### PR TITLE
ci: add regenerate-artifacts composite action

### DIFF
--- a/.github/actions/regenerate-artifacts/action.yml
+++ b/.github/actions/regenerate-artifacts/action.yml
@@ -1,0 +1,28 @@
+name: Regenerate distribution artifacts
+description: Run the build scripts that regenerate config, lockfiles, Containerfile, and verify secrets
+
+inputs:
+  ogx-version:
+    description: 'OGX version to set (overrides OGX_VERSION from build.env)'
+    required: false
+    default: ''
+  working-directory:
+    description: 'Working directory for running build scripts'
+    required: false
+    default: '.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Regenerate distribution artifacts
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        OGX_VERSION_OVERRIDE: ${{ inputs.ogx-version }}
+      run: |
+        if [ -n "$OGX_VERSION_OVERRIDE" ]; then
+          export OGX_VERSION="$OGX_VERSION_OVERRIDE"
+        fi
+        uv run build/gen_config.py
+        ./build/run_gen_lockfile.sh
+        uv run build/gen_containerfile.py


### PR DESCRIPTION
## Summary
- Adds the `regenerate-artifacts` composite action to `release-3.5-ea.2`, which predates its introduction on `main`
- The `create-or-update-release-branch` workflow uses `uses: ./.github/actions/regenerate-artifacts`, which resolves from the working tree — when the release branch doesn't have the action, the step fails ([failed run](https://github.com/opendatahub-io/ogx-distribution/actions/runs/30297245279/job/90081186204))

## Test plan
- [ ] Re-dispatch the `create-or-update-release-branch` event targeting `release-3.5-ea.2` after merge

🤖 Generated with [Claude Code](https://claude.ai/code)