### PR TITLE
chore: bump OGX version to v0.4.7+rhai0

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -12,7 +12,9 @@ RUN uv pip install --prerelease=allow --upgrade \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2' \
-    'setuptools==81.0.0'
+    'setuptools==81.0.0' \
+    'pillow>=12.3.0' \
+    'nltk>=3.10.0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -16,8 +16,12 @@ RUN uv pip install --prerelease=allow --upgrade \
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \
+    'litellm>=1.83.7' \
     'mcp>=1.23.0' \
+    'nltk>=3.9.4' \
+    'pillow>=12.2.0' \
     'pymilvus[milvus-lite]>=2.4.10' \
+    'pypdf>=6.7.2' \
     aiosqlite \
     asyncpg \
     autoevals \
@@ -29,17 +33,13 @@ RUN uv pip install --prerelease=allow \
     fire \
     google-cloud-aiplatform \
     httpx \
-    litellm \
     matplotlib \
-    nltk \
     numpy \
     opentelemetry-exporter-otlp-proto-http \
     opentelemetry-sdk \
     pandas \
-    pillow \
     psycopg2-binary \
     pymongo \
-    pypdf \
     qdrant-client \
     redis \
     requests \
@@ -64,9 +64,9 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
-RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
-RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.4
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.7+rhai0
+RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
+RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.2.1+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.2.1+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.7+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.7+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,10 +15,10 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "v0.4.2.1+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "v0.4.7+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
-LLAMA_STACK_CLIENT_VERSION = "v0.4.2"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
-LLAMA_STACK_API_VERSION = "v0.4.4"  # pre-0.4.4 had broken packaging (llama-stack#4777)
+LLAMA_STACK_CLIENT_VERSION = "v0.4.7"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
+LLAMA_STACK_API_VERSION = "v0.4.7"  # pre-0.4.4 had broken packaging (llama-stack#4777)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
 ]

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -33,6 +33,8 @@ PINNED_DEPENDENCIES = [
     "'ibm-cos-sdk-core==2.14.2'",
     "'ibm-cos-sdk==2.14.2'",
     "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
+    "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
+    "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the distribution to Llama Stack version 0.4.7.
  - Added refreshed dependency versions, including Pillow and supporting data science, document-processing, and model-integration packages.

- **Documentation**
  - Updated the distribution documentation to reflect Llama Stack version 0.4.7+rhai0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->