### PR TITLE
fix: pin langchain ecosystem to 0.3.x for ragas compatibility (3.3)

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -14,7 +14,12 @@ RUN uv pip install --prerelease=allow --upgrade \
     'ibm-cos-sdk==2.14.2' \
     'setuptools==81.0.0' \
     'pillow>=12.3.0' \
-    'nltk>=3.10.0'
+    'nltk>=3.10.0' \
+    'langchain<1.0.0,>=0.3.0' \
+    'langchain-community<0.4,>=0.3.0' \
+    'langchain-core<1.0.0,>=0.3.86' \
+    'langchain-openai<1.0.0,>=0.3.0' \
+    'langchain-text-splitters<1.0.0,>=0.3.0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -35,6 +35,11 @@ PINNED_DEPENDENCIES = [
     "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
     "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
     "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
+    "'langchain<1.0.0,>=0.3.0'",  # ragas requires langchain 0.3.x
+    "'langchain-community<0.4,>=0.3.0'",
+    "'langchain-core<1.0.0,>=0.3.86'",
+    "'langchain-openai<1.0.0,>=0.3.0'",
+    "'langchain-text-splitters<1.0.0,>=0.3.0'",
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}


### PR DESCRIPTION
## Summary

Pin the langchain ecosystem to 0.3.x to fix smoke test crash.

**Root cause:** `ragas` imports `langchain_community.chat_models.vertexai` which was removed in `langchain-community` 0.4+. Without version constraints, the resolver installs 0.4+/1.0+ and the OGX server crashes on startup.

**Error:** `ModuleNotFoundError: No module named 'langchain_community.chat_models.vertexai'`

**Fix:** Add langchain pins to `PINNED_DEPENDENCIES` in `build.py`, matching the pipeline repo constraints:
- `langchain<1.0.0,>=0.3.0`
- `langchain-community<0.4,>=0.3.0`
- `langchain-core<1.0.0,>=0.3.86`
- `langchain-openai<1.0.0,>=0.3.0`
- `langchain-text-splitters<1.0.0,>=0.3.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application environment to include LangChain packages with compatible version constraints.
  * Added the same pinned package versions to generated container builds for more consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->