### PR TITLE
fix: replace personal vLLM image with official ODH image (3.3)

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -1,28 +1,32 @@
-name: Setup VLLM
-description: Start VLLM
+name: Setup vLLM
+description: Start vLLM
 runs:
   using: "composite"
   steps:
-    - name: Start VLLM
+    - name: Start vLLM container
       shell: bash
       run: |
+        # Set VLLM_ARGS based on VLLM_MODE
+        if [[ "$VLLM_MODE" == "inference" ]]; then
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /opt/vllm/models/Qwen/Qwen3.5-0.8B --served-model-name Qwen/Qwen3.5-0.8B --max-model-len 8192"
+          VLLM_PORT=8000
+        elif [[ "$VLLM_MODE" == "embedding" ]]; then
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
+          VLLM_PORT=8001
+        else
+          echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"
+          exit 1
+        fi
+
         # Start vllm container
         docker run -d \
-          --name vllm \
-          --privileged=true \
+          --name vllm-$VLLM_MODE \
           --net=host \
-          quay.io/higginsd/vllm-cpu:65393ee064-qwen3 \
-          --host 0.0.0.0 \
-          --port 8000 \
-          --enable-auto-tool-choice \
-          --tool-call-parser hermes \
-          --model /root/.cache/Qwen3-0.6B \
-          --served-model-name Qwen/Qwen3-0.6B \
-          --max-model-len 8192
+          $VLLM_IMAGE \
+          $VLLM_ARGS
 
-          # Wait for vllm to be ready
-          echo "Waiting for vllm to be ready..."
-          timeout 900 bash -c 'until curl -fsS http://localhost:8000/health >/dev/null; do
-            echo "Waiting for vllm..."
-            sleep 5
-          done'
+        echo "Waiting for vllm to be ready on port $VLLM_PORT..."
+        timeout 900 bash -c "until curl -fsS http://localhost:$VLLM_PORT/health >/dev/null; do
+          echo 'Waiting for vllm...'
+          sleep 5
+        done"

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -11,7 +11,8 @@ RUN uv pip install --prerelease=allow --upgrade \
     'boto3==1.35.88' \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
-    'ibm-cos-sdk==2.14.2'
+    'ibm-cos-sdk==2.14.2' \
+    'setuptools==81.0.0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -66,6 +66,7 @@ RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
+RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.4
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -12,7 +12,9 @@ RUN uv pip install --prerelease=allow --upgrade \
     'aiobotocore==2.16.1' \
     'ibm-cos-sdk-core==2.14.2' \
     'ibm-cos-sdk==2.14.2' \
-    'setuptools==81.0.0'
+    'setuptools==81.0.0' \
+    'pillow>=12.3.0' \
+    'nltk>=3.10.0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -16,8 +16,12 @@ RUN uv pip install --prerelease=allow --upgrade \
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \
+    'litellm>=1.83.7' \
     'mcp>=1.23.0' \
+    'nltk>=3.9.4' \
+    'pillow>=12.2.0' \
     'pymilvus[milvus-lite]>=2.4.10' \
+    'pypdf>=6.7.2' \
     aiosqlite \
     asyncpg \
     autoevals \
@@ -29,17 +33,13 @@ RUN uv pip install --prerelease=allow \
     fire \
     google-cloud-aiplatform \
     httpx \
-    litellm \
     matplotlib \
-    nltk \
     numpy \
     opentelemetry-exporter-otlp-proto-http \
     opentelemetry-sdk \
     pandas \
-    pillow \
     psycopg2-binary \
     pymongo \
-    pypdf \
     qdrant-client \
     redis \
     requests \
@@ -64,9 +64,9 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
 RUN uv pip install --prerelease=allow --no-deps sentence-transformers
-RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.2.1+rhai0
-RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.2
-RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.4
+RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.7+rhai0
+RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
+RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -4,7 +4,7 @@
 
 This image contains the official Open Data Hub Llama Stack distribution, with all the packages and configuration needed to run a Llama Stack server in a containerized environment.
 
-The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.2.1+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.2.1+rhai0)
+The image is currently shipping with the Open Data Hub version of Llama Stack version [0.4.7+rhai0](https://github.com/opendatahub-io/llama-stack/releases/tag/v0.4.7+rhai0)
 
 You can see an overview of the APIs and Providers the image ships with in the table below.
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -31,6 +31,7 @@ PINNED_DEPENDENCIES = [
     "'aiobotocore==2.16.1'",
     "'ibm-cos-sdk-core==2.14.2'",
     "'ibm-cos-sdk==2.14.2'",
+    "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -18,6 +18,7 @@ from pathlib import Path
 CURRENT_LLAMA_STACK_VERSION = "v0.4.2.1+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
 LLAMA_STACK_CLIENT_VERSION = "v0.4.2"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
+LLAMA_STACK_API_VERSION = "v0.4.4"  # pre-0.4.4 had broken packaging (llama-stack#4777)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
 ]
@@ -35,7 +36,8 @@ PINNED_DEPENDENCIES = [
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}
-RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}"""
+RUN uv pip install --no-cache --no-deps llama-stack-client=={llama_stack_client_version}
+RUN uv pip install --no-cache --no-deps llama-stack-api=={llama_stack_api_version}"""
 
 
 def get_llama_stack_install(llama_stack_version):
@@ -51,6 +53,7 @@ def get_llama_stack_install(llama_stack_version):
         return source_install_command.format(
             llama_stack_version=llama_stack_version,
             llama_stack_client_version=llama_stack_client_version,
+            llama_stack_api_version=LLAMA_STACK_API_VERSION,
         ).rstrip()
 
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -15,10 +15,10 @@ import re
 import shlex
 from pathlib import Path
 
-CURRENT_LLAMA_STACK_VERSION = "v0.4.2.1+rhai0"
+CURRENT_LLAMA_STACK_VERSION = "v0.4.7+rhai0"
 LLAMA_STACK_VERSION = os.getenv("LLAMA_STACK_VERSION", CURRENT_LLAMA_STACK_VERSION)
-LLAMA_STACK_CLIENT_VERSION = "v0.4.2"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
-LLAMA_STACK_API_VERSION = "v0.4.4"  # pre-0.4.4 had broken packaging (llama-stack#4777)
+LLAMA_STACK_CLIENT_VERSION = "v0.4.7"  # Set to None to auto-derive from LLAMA_STACK_VERSION, or set explicit version
+LLAMA_STACK_API_VERSION = "v0.4.7"  # pre-0.4.4 had broken packaging (llama-stack#4777)
 BASE_REQUIREMENTS = [
     f"llama-stack=={LLAMA_STACK_VERSION}",
 ]

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -33,6 +33,8 @@ PINNED_DEPENDENCIES = [
     "'ibm-cos-sdk-core==2.14.2'",
     "'ibm-cos-sdk==2.14.2'",
     "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
+    "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
+    "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -328,6 +328,10 @@ registered_resources:
     provider_id: tavily-search
   - toolgroup_id: builtin::rag
     provider_id: rag-runtime
+vector_stores:
+  annotation_prompt_params:
+    enable_annotations: true
+    annotation_instruction_template: "Cite sources immediately at the end of sentences using <|file-id|> format."
 telemetry:
   enabled: true
 server:


### PR DESCRIPTION
## Summary

Replace the personal vLLM CPU image (`quay.io/higginsd/vllm-cpu`) with the official ODH image (`quay.io/opendatahub/vllm-cpu`) in the CI setup-vllm action.

The personal image is no longer maintained (owner on leave), causing CI smoke tests to fail with vLLM startup timeout on port 8000.

Changes:
- Image: `higginsd/vllm-cpu:65393ee064-qwen3` → `opendatahub/vllm-cpu:Qwen3.5-0.8B-granite-embedding-125m-english`
- Model path: `/root/.cache/Qwen3-0.6B` → `/opt/vllm/models/Qwen/Qwen3.5-0.8B`
- Model name: `Qwen/Qwen3-0.6B` → `Qwen/Qwen3.5-0.8B`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the VLLM service configuration to use the latest CPU image and embedding model.
  * Updated the served model path and identifier to match the new model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->