### PR TITLE
fix: pin mcp<2.0.0, langchain-community==0.4.1, and update Vertex AI model (3.4)

### DIFF
--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -8,10 +8,10 @@ runs:
       run: |
         # Set VLLM_ARGS based on VLLM_MODE
         if [[ "$VLLM_MODE" == "inference" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /root/.cache/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192"
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /opt/vllm/models/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192"
           VLLM_PORT=8000
         elif [[ "$VLLM_MODE" == "embedding" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /root/.cache/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
           VLLM_PORT=8001
         else
           echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"

--- a/.github/actions/setup-vllm/action.yml
+++ b/.github/actions/setup-vllm/action.yml
@@ -8,10 +8,10 @@ runs:
       run: |
         # Set VLLM_ARGS based on VLLM_MODE
         if [[ "$VLLM_MODE" == "inference" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /opt/vllm/models/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192"
+          VLLM_ARGS="--host 0.0.0.0 --port 8000 --enable-auto-tool-choice --tool-call-parser hermes --model /root/.cache/Qwen/Qwen3-0.6B --served-model-name Qwen/Qwen3-0.6B --max-model-len 8192"
           VLLM_PORT=8000
         elif [[ "$VLLM_MODE" == "embedding" ]]; then
-          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /opt/vllm/models/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
+          VLLM_ARGS="--host 0.0.0.0 --port 8001 --model /root/.cache/ibm-granite/granite-embedding-125m-english --served-model-name ibm-granite/granite-embedding-125m-english"
           VLLM_PORT=8001
         else
           echo "Error: VLLM_MODE must be set to 'inference' or 'embedding'"

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -63,7 +63,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       # Model names - set defaults, overridden by MaaS configuration step
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-3.5-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-4o-mini
       EMBEDDING_MODEL: vllm-embedding/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -63,7 +63,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       # Model names - set defaults, overridden by MaaS configuration step
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-2.0-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/publishers/google/models/gemini-3.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-4o-mini
       EMBEDDING_MODEL: vllm-embedding/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
         files: ^distribution/.*$
         additional_dependencies:
           - uv>=0.9.0
+          - mcp>=1.23.0,<2.0.0
 
       - id: doc-gen
         name: Distribution Documentation

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -17,7 +17,8 @@ RUN uv pip install --upgrade \
     'setuptools==81.0.0' \
     'pillow>=12.3.0' \
     'nltk>=3.10.0' \
-    'mcp>=1.23.0,<2.0.0'
+    'mcp>=1.23.0,<2.0.0' \
+    'langchain-community==0.4.1'
 RUN uv pip install \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -16,7 +16,8 @@ RUN uv pip install --upgrade \
     'ibm-cos-sdk==2.14.2' \
     'setuptools==81.0.0' \
     'pillow>=12.3.0' \
-    'nltk>=3.10.0'
+    'nltk>=3.10.0' \
+    'mcp>=1.23.0,<2.0.0'
 RUN uv pip install \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -36,6 +36,7 @@ PINNED_DEPENDENCIES = [
     "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
     "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
     "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
+    "'mcp>=1.23.0,<2.0.0'",  # mcp 2.0 renamed McpError, breaks llama-stack 0.7.x
 ]
 
 source_install_command_pypi_client = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -37,6 +37,7 @@ PINNED_DEPENDENCIES = [
     "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
     "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
     "'mcp>=1.23.0,<2.0.0'",  # mcp 2.0 renamed McpError, breaks llama-stack 0.7.x
+    "'langchain-community==0.4.1'",  # 0.4.2 removed chat_models.vertexai, breaks ragas
 ]
 
 source_install_command_pypi_client = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}


### PR DESCRIPTION
## Summary

Fix CI failures on rhoai-v3.4 caused by recent upstream dependency changes:

- **mcp<2.0.0**: mcp 2.0.0 (released 2026-07-28) renamed `McpError` to `MCPError`, crashing llama-stack on import. Pinned in `PINNED_DEPENDENCIES` and `.pre-commit-config.yaml`.
- **langchain-community==0.4.1**: `langchain-community` 0.4.2 removed `chat_models.vertexai`, breaking ragas import. Pin to 0.4.1 (last version with the stub).
- **Vertex AI model**: `gemini-2.0-flash` was discontinued June 1, 2026. Updated to `gemini-2.5-flash`.