### PR TITLE
fix: align ragas provider (0.5.4) and pin langchain-community==0.4.1 for lls 0.4.x

### DIFF
--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -57,9 +57,9 @@ RUN uv pip install --prerelease=allow \
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_lmeval==0.4.2
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[inline]==0.5.1
+    llama_stack_provider_ragas[inline]==0.5.4
 RUN uv pip install --prerelease=allow \
-    llama_stack_provider_ragas[remote]==0.5.1
+    llama_stack_provider_ragas[remote]==0.5.4
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.3.2
 RUN uv pip install --prerelease=allow \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -14,7 +14,8 @@ RUN uv pip install --prerelease=allow --upgrade \
     'ibm-cos-sdk==2.14.2' \
     'setuptools==81.0.0' \
     'pillow>=12.3.0' \
-    'nltk>=3.10.0'
+    'nltk>=3.10.0' \
+    'langchain-community==0.4.1'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -14,10 +14,10 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | batches | inline::reference | No | ✅ | N/A |
 | datasetio | inline::localfs | No | ✅ | N/A |
 | datasetio | remote::huggingface | No | ✅ | N/A |
-| eval | inline::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
+| eval | inline::trustyai_ragas | Yes (version 0.5.4) | ❌ | Set the `TRUSTYAI_EMBEDDING_MODEL` environment variable |
 | eval | remote::trustyai_garak | Yes (version 0.1.8) | ❌ | Set the `ENABLE_KUBEFLOW_GARAK` environment variable |
 | eval | remote::trustyai_lmeval | Yes (version 0.4.2) | ✅ | N/A |
-| eval | remote::trustyai_ragas | Yes (version 0.5.1) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
+| eval | remote::trustyai_ragas | Yes (version 0.5.4) | ❌ | Set the `ENABLE_KUBEFLOW_RAGAS` environment variable |
 | files | inline::localfs | No | ✅ | N/A |
 | files | remote::s3 | No | ❌ | Set the `ENABLE_S3` environment variable |
 | inference | inline::sentence-transformers | No | ❌ | Set the `ENABLE_SENTENCE_TRANSFORMERS` environment variable |

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -35,6 +35,11 @@ PINNED_DEPENDENCIES = [
     "'setuptools==81.0.0'",  # due to bug in milvus-lite with unreleased fix: https://github.com/milvus-io/milvus-lite/pull/323
     "'pillow>=12.3.0'",  # CVE-2026-42311, CVE-2026-55379/55380/54060
     "'nltk>=3.10.0'",  # CVE-2026-54293, CVE-2026-12243
+    # ragas 0.3.0 (pulled in by llama_stack_provider_ragas) imports
+    # langchain_community.chat_models.vertexai.ChatVertexAI at import time.
+    # That stub was removed in langchain-community 0.4.2; 0.4.1 is the last
+    # release that still ships it (and stays on the langchain-core 1.0.x line).
+    "'langchain-community==0.4.1'",
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}

--- a/distribution/config.yaml
+++ b/distribution/config.yaml
@@ -142,12 +142,12 @@ providers:
       base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
   - provider_id: ${env.TRUSTYAI_EMBEDDING_MODEL:+trustyai_ragas_inline}
     provider_type: inline::trustyai_ragas
-    module: llama_stack_provider_ragas.inline==0.5.1
+    module: llama_stack_provider_ragas.inline==0.5.4
     config:
       embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
   - provider_id: ${env.ENABLE_KUBEFLOW_RAGAS:+trustyai_ragas_remote}
     provider_type: remote::trustyai_ragas
-    module: llama_stack_provider_ragas.remote==0.5.1
+    module: llama_stack_provider_ragas.remote==0.5.4
     config:
       embedding_model: ${env.TRUSTYAI_EMBEDDING_MODEL:=}
       kubeflow_config:


### PR DESCRIPTION
## Summary

Two related fixes for the ragas eval provider on the `rhoai-v3.3` (llama-stack 0.4.7) distro:

### 1. Fix distro startup crash (`ModuleNotFoundError` in ragas)

The build currently fails at *"Start and smoke test LLS distro image"* ([failing run](https://github.com/opendatahub-io/ogx-distribution/actions/runs/30355798154/job/90263654299)) with:

```
File ".../llama_stack_provider_ragas/inline/ragas_inline_eval.py", line 6, in <module>
    from ragas import EvaluationDataset
  ...
  File ".../ragas/llms/base.py", line 8, in <module>
    from langchain_community.chat_models.vertexai import ChatVertexAI
ModuleNotFoundError: No module named 'langchain_community.chat_models.vertexai'
```

Root cause: `llama_stack_provider_ragas` (both 0.5.x and 0.6.x) hard-pins **`ragas==0.3.0`**, which imports `ChatVertexAI` from `langchain_community.chat_models.vertexai` at import time but declares `langchain-community` with **no upper bound**. The image therefore resolved **langchain-community 0.4.2**, which *removed* that compat stub.

**Fix:** pin **`langchain-community==0.4.1`** — the last release that still ships the stub, and which stays on the same `langchain-core` 1.0.x line the build already resolves (so it's the minimal change). Added to `PINNED_DEPENDENCIES` so it installs before ragas pulls langchain-community transitively.

| langchain-community | vertexai stub | langchain-core |
|---|---|---|
| 0.4.2 (resolved today) | ❌ removed | 1.0.x |
| **0.4.1 (pinned)** | ✅ present, imports cleanly | 1.0.x (unchanged) |

### 2. Align ragas provider version with the compatibility matrix

The distro targets **llama-stack 0.4.7** but pinned the ragas provider at **0.5.1**, which per the provider [COMPATIBILITY.md](https://github.com/trustyai-explainability/llama-stack-provider-ragas/blob/main/COMPATIBILITY.md) is a legacy release for llama-stack 0.2.x/0.3.x. The recommended provider for llama-stack 0.4.x is **0.5.4**. Bumped inline + remote `0.5.1` → `0.5.4`.

> Note: both 0.5.1 and 0.5.4 pin `ragas==0.3.0`, so this bump alone does **not** fix the crash — hence fix #1.

## Changes

- `distribution/config.yaml` — ragas provider modules `0.5.1` → `0.5.4`
- `distribution/build.py` — add `langchain-community==0.4.1` to `PINNED_DEPENDENCIES`
- `distribution/Containerfile` — regenerated (ragas `0.5.4`, langchain-community pin)
- `distribution/README.md` — provider table version `0.5.4`

> `Containerfile` is auto-generated from `config.yaml` + `build.py` via `distribution/build.py`. Edits were verified byte-for-byte equivalent to a regeneration for these specific changes; no other resolved deps were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
