### PR TITLE
fix: pin mcp<2.0.0 to fix McpError import (3.3)

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -50,7 +50,7 @@ jobs:
       # Deployment configuration - Llama Stack will support vLLM, Vertex AI, and OpenAI
       # Model names include provider prefixes for consistency
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/google/gemini-2.0-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/google/gemini-3.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-4o-mini
       EMBEDDING_MODEL: sentence-transformers/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1

--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -50,7 +50,7 @@ jobs:
       # Deployment configuration - Llama Stack will support vLLM, Vertex AI, and OpenAI
       # Model names include provider prefixes for consistency
       VLLM_INFERENCE_MODEL: vllm-inference/Qwen/Qwen3-0.6B
-      VERTEX_AI_INFERENCE_MODEL: vertexai/google/gemini-3.5-flash
+      VERTEX_AI_INFERENCE_MODEL: vertexai/google/gemini-2.5-flash
       OPENAI_INFERENCE_MODEL: openai/gpt-4o-mini
       EMBEDDING_MODEL: sentence-transformers/ibm-granite/granite-embedding-125m-english
       VLLM_URL: http://localhost:8000/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
         files: ^distribution/.*$
         additional_dependencies:
           - uv>=0.9.0
+          - mcp>=1.23.0,<2.0.0
 
       - id: doc-gen
         name: Distribution Documentation

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -16,7 +16,8 @@ RUN uv pip install --prerelease=allow --upgrade \
     'pillow>=12.3.0' \
     'nltk>=3.10.0' \
     'langchain-community==0.4.1' \
-    'mcp>=1.23.0,<2.0.0'
+    'mcp>=1.23.0,<2.0.0' \
+    'tokenizers>=0.21,<0.23.0rc0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \
@@ -66,9 +67,8 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.3.2
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
-RUN uv pip install --prerelease=allow \
-    sentence-transformers
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
+RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.7+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
 RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -15,7 +15,8 @@ RUN uv pip install --prerelease=allow --upgrade \
     'setuptools==81.0.0' \
     'pillow>=12.3.0' \
     'nltk>=3.10.0' \
-    'langchain-community==0.4.1'
+    'langchain-community==0.4.1' \
+    'mcp>=1.23.0,<2.0.0'
 RUN uv pip install --prerelease=allow \
     'datasets>=4.0.0' \
     'fonttools>=4.60.2' \

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -72,6 +72,8 @@ RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/ll
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
 RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
+# Download embedding model at build time to avoid runtime download failures
+RUN python3 -c "from huggingface_hub import snapshot_download; snapshot_download('ibm-granite/granite-embedding-125m-english')"
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 #TODO: remove this once we have a stable version of llama-stack

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -73,8 +73,6 @@ RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/ll
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
 RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7
 RUN mkdir -p ${HOME}/.llama ${HOME}/.cache
-# Download embedding model at build time to avoid runtime download failures
-RUN python3 -c "from huggingface_hub import snapshot_download; snapshot_download('ibm-granite/granite-embedding-125m-english')"
 COPY distribution/config.yaml ${APP_ROOT}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${APP_ROOT}/entrypoint.sh
 #TODO: remove this once we have a stable version of llama-stack

--- a/distribution/Containerfile
+++ b/distribution/Containerfile
@@ -66,8 +66,9 @@ RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_fms==0.3.2
 RUN uv pip install --prerelease=allow \
     llama_stack_provider_trustyai_garak==0.1.8
+RUN uv pip install --prerelease=allow \
+    sentence-transformers
 RUN uv pip install --prerelease=allow --extra-index-url https://download.pytorch.org/whl/cpu 'torchao>=0.12.0' torch torchvision
-RUN uv pip install --prerelease=allow --no-deps sentence-transformers
 RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@v0.4.7+rhai0
 RUN uv pip install --no-cache --no-deps llama-stack-client==v0.4.7
 RUN uv pip install --no-cache --no-deps llama-stack-api==v0.4.7

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -7,6 +7,10 @@ RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {llama_stack_install_source}
 
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
+
+# Download embedding model at build time to avoid runtime download failures
+RUN python3 -c "from huggingface_hub import snapshot_download; snapshot_download('ibm-granite/granite-embedding-125m-english')"
+
 COPY distribution/config.yaml ${{APP_ROOT}}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh
 

--- a/distribution/Containerfile.in
+++ b/distribution/Containerfile.in
@@ -7,10 +7,6 @@ RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
 {llama_stack_install_source}
 
 RUN mkdir -p ${{HOME}}/.llama ${{HOME}}/.cache
-
-# Download embedding model at build time to avoid runtime download failures
-RUN python3 -c "from huggingface_hub import snapshot_download; snapshot_download('ibm-granite/granite-embedding-125m-english')"
-
 COPY distribution/config.yaml ${{APP_ROOT}}/config.yaml
 COPY --chmod=755 distribution/entrypoint.sh ${{APP_ROOT}}/entrypoint.sh
 

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -220,6 +220,12 @@ def get_dependencies():
             ]
             packages = sorted(set(packages))
 
+            # sentence-transformers needs its deps for model loading
+            if "--no-deps" in flags and any(
+                "sentence-transformers" in p for p in packages
+            ):
+                flags.remove("--no-deps")
+
             # Build the command based on flags
             if extra_index_url or "--index-url" in flags:
                 # Torch dependencies with extra index URL

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -41,6 +41,7 @@ PINNED_DEPENDENCIES = [
     # release that still ships it (and stays on the langchain-core 1.0.x line).
     "'langchain-community==0.4.1'",
     "'mcp>=1.23.0,<2.0.0'",  # mcp 2.0 renamed McpError, breaks llama-stack 0.7.x
+    "'tokenizers>=0.21,<0.23.0rc0'",  # 0.23.0rc0 breaks granite-embedding model loading
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}
@@ -219,12 +220,6 @@ def get_dependencies():
                 for package in packages
             ]
             packages = sorted(set(packages))
-
-            # sentence-transformers needs its deps for model loading
-            if "--no-deps" in flags and any(
-                "sentence-transformers" in p for p in packages
-            ):
-                flags.remove("--no-deps")
 
             # Build the command based on flags
             if extra_index_url or "--index-url" in flags:

--- a/distribution/build.py
+++ b/distribution/build.py
@@ -40,6 +40,7 @@ PINNED_DEPENDENCIES = [
     # That stub was removed in langchain-community 0.4.2; 0.4.1 is the last
     # release that still ships it (and stays on the langchain-core 1.0.x line).
     "'langchain-community==0.4.1'",
+    "'mcp>=1.23.0,<2.0.0'",  # mcp 2.0 renamed McpError, breaks llama-stack 0.7.x
 ]
 
 source_install_command = """RUN uv pip install --no-cache --no-deps git+https://github.com/opendatahub-io/llama-stack.git@{llama_stack_version}


### PR DESCRIPTION
## Summary

Pin `mcp>=1.23.0,<2.0.0` to fix `McpError` import error.

mcp 2.0.0 (released 2026-07-28) renamed `McpError` to `MCPError`, breaking llama-stack imports. Added pin in:
- `distribution/build.py` `PINNED_DEPENDENCIES` (container build)
- `.pre-commit-config.yaml` `additional_dependencies` (pre-commit)
- Regenerated `distribution/Containerfile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated distribution and validation tooling for improved compatibility and more consistent builds.
  - Updated container-based validation to use the newer Gemini 2.5 Flash inference model.
  - Refined supported runtime package versions across local checks and distribution workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->