### PR TITLE
ci(mergify): migrate commit_message_template to commit_message_format

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -27,14 +27,11 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        commit_message_template: |
-          {{ title }} (#{{ number }})
-
-          {{ body }}
-
-          {% for user in approved_reviews_by %}
-          Approved-by: {{ user }}
-          {% endfor %}
+        commit_message_format:
+          title: pr-title
+          body: pr-body
+          trailers:
+            - approved-by
 
   - name: auto-merge
     description: >
@@ -74,14 +71,11 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        commit_message_template: |
-          {{ title }} (#{{ number }})
-
-          {{ body }}
-
-          {% for user in approved_reviews_by %}
-          Approved-by: {{ user }}
-          {% endfor %}
+        commit_message_format:
+          title: pr-title
+          body: pr-body
+          trailers:
+            - approved-by
 
   - name: ping author on conflicts and add 'needs-rebase' label
     conditions:


### PR DESCRIPTION
## Summary
- Replace deprecated Jinja2 `commit_message_template` with the declarative `commit_message_format` syntax in both auto-merge rules
- Functionally identical: same PR title with number, PR body, and approved-by trailers
- Mergify requires this migration by 2026-09-30

Ref: #475

## Test plan
- [ ] Mergify validates the config on push (no errors in PR checks)
- [ ] Verify next merged PR produces the expected commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the consistency and clarity of automatically generated merge commit messages.
  * Standardized commit titles, descriptions, and approval attribution for better release traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->