### PR TITLE
fix: use odh-ogx-core Quay repo instead of llama-stack (3.4)

### DIFF
--- a/.github/workflows/redhat-distro-container.yml
+++ b/.github/workflows/redhat-distro-container.yml
@@ -40,7 +40,7 @@ concurrency:
 
 env:
   REGISTRY: quay.io
-  IMAGE_NAME: quay.io/opendatahub/llama-stack # tags for the image will be added dynamically
+  IMAGE_NAME: quay.io/opendatahub/odh-ogx-core # tags for the image will be added dynamically
 
 jobs:
   build-test:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Red Hat distribution container image target used by automated builds, tests, publishing, tagging, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->