### PR TITLE
chore: trigger publish to new Quay repo (3.4)

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -42,3 +42,4 @@ You can see an overview of the APIs and Providers the image ships with in the ta
 | vector_io | remote::milvus | No | ❌ | Set the `MILVUS_ENDPOINT` environment variable |
 | vector_io | remote::pgvector | No | ❌ | Set the `ENABLE_PGVECTOR` environment variable |
 | vector_io | remote::qdrant | No | ❌ | Set the `ENABLE_QDRANT` environment variable |
+<!-- v0.7.3+rhaiv.0 -->


### PR DESCRIPTION
## Summary

Trivial change to `distribution/README.md` to trigger the publish job.

PR #552 updated the Quay push endpoint from `llama-stack` to `odh-ogx-core`, but the publish job was skipped because no `distribution/` files were modified. This PR triggers a rebuild+publish to the correct Quay repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the distribution README by adding spacing after the provider table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->