### PR TITLE
test: re-enable async integration tests and add AsyncOgxClient notebook

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -81,6 +81,9 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_tool_with_complex_schema`
 - `test_tool_without_schema`
 
+**Structured output test times out on CPU:**
+- `test_openai_chat_completion_structured_output`
+
 **Requires vLLM >= v0.12.0** ([ogx/ogx#4984](https://github.com/ogx/ogx/issues/4984)):
 - `test_openai_completion_guided_choice`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,8 +81,10 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_tool_with_complex_schema`
 - `test_tool_without_schema`
 
-**Structured output test times out on CPU:**
+**Structured output and tool-calling tests timing out on CPU:**
 - `test_openai_chat_completion_structured_output`
+- `test_simple_tool_call`
+- `test_streaming_tool_calls`
 
 **Requires vLLM >= v0.12.0** ([ogx/ogx#4984](https://github.com/ogx/ogx/issues/4984)):
 - `test_openai_completion_guided_choice`

--- a/tests/functional/notebooks/test_async_client.ipynb
+++ b/tests/functional/notebooks/test_async_client.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Scenario: AsyncOgxClient SDK Coverage\n",
+    "# Scenario: Async OpenAI Client Coverage\n",
     "\n",
-    "Validates that `AsyncOgxClient` from `ogx_client` operates properly with async/await methods across key endpoints:\n",
-    "- **Inspect / Health:** `client.inspect.health()`\n",
+    "Validates that `AsyncOpenAI` from `openai` operates properly with async/await methods against the OGX server:\n",
+    "- **Server Health:** `client.get(\"/health\")`\n",
     "- **Models:** `client.models.list()`\n",
     "- **Responses API:** `client.responses.create()`\n",
     "- **Chat Completions:** `client.chat.completions.create()`\n",
@@ -20,7 +20,7 @@
    "source": [
     "## Setup & Initialization\n",
     "\n",
-    "Load configuration from environment variables and initialize `AsyncOgxClient`."
+    "Load configuration from environment variables and initialize `AsyncOpenAI`."
    ]
   },
   {
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from ogx_client import AsyncOgxClient\n",
+    "from openai import AsyncOpenAI\n",
     "from scripts.helpers import response_text\n",
     "\n",
     "base_url = os.environ.get(\"BASE_URL\", \"http://localhost:8321\")\n",
@@ -41,19 +41,21 @@
     "assert base_url, \"BASE_URL must be set\"\n",
     "assert model, \"INFERENCE_MODEL must be set\"\n",
     "\n",
-    "ogx_base_url = base_url.rstrip(\"/\")\n",
-    "ogx_base_url = ogx_base_url if ogx_base_url.endswith(\"/v1\") else ogx_base_url + \"/v1\"\n",
+    "openai_base_url = base_url.rstrip(\"/\")\n",
+    "openai_base_url = (\n",
+    "    openai_base_url if openai_base_url.endswith(\"/v1\") else openai_base_url + \"/v1\"\n",
+    ")\n",
     "\n",
-    "client = AsyncOgxClient(base_url=ogx_base_url)"
+    "client = AsyncOpenAI(api_key=\"no-key-needed\", base_url=openai_base_url)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Server Health Check (`inspect.health`)\n",
+    "## Server Health Check (`/v1/health`)\n",
     "\n",
-    "Verify `await client.inspect.health()` completes and returns valid health status."
+    "Verify `await client.get(\"/health\")` completes and returns status OK."
    ]
   },
   {
@@ -62,10 +64,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "health = await client.inspect.health()\n",
-    "assert health is not None, \"Expected health response to be non-None\"\n",
-    "health_status = getattr(health, \"status\", health)\n",
-    "assert health_status == \"OK\", f\"Health check failed or unexpected response: {health!r}\""
+    "health_resp = await client.get(\"/health\", cast_to=object)\n",
+    "assert health_resp is not None, \"Expected health response\"\n",
+    "health_status = (\n",
+    "    health_resp.get(\"status\")\n",
+    "    if isinstance(health_resp, dict)\n",
+    "    else getattr(health_resp, \"status\", str(health_resp))\n",
+    ")\n",
+    "assert health_status == \"OK\" or health_resp == \"OK\", (\n",
+    "    f\"Health check failed or unexpected response: {health_resp!r}\"\n",
+    ")"
    ]
   },
   {
@@ -85,11 +93,7 @@
    "source": [
     "models_resp = await client.models.list()\n",
     "assert models_resp is not None, \"Expected models response\"\n",
-    "model_ids = []\n",
-    "if hasattr(models_resp, \"data\"):\n",
-    "    model_ids = [m.id for m in models_resp.data]\n",
-    "elif isinstance(models_resp, list):\n",
-    "    model_ids = [getattr(m, \"id\", str(m)) for m in models_resp]\n",
+    "model_ids = [m.id for m in models_resp.data]\n",
     "\n",
     "assert len(model_ids) > 0, \"Expected at least one model in list\"\n",
     "assert any(model in mid or mid in model for mid in model_ids), (\n",
@@ -191,7 +195,7 @@
    "source": [
     "## Context Manager & Cleanup\n",
     "\n",
-    "Verify that `AsyncOgxClient` works as an async context manager and closes properly."
+    "Verify that `AsyncOpenAI` works as an async context manager and closes properly."
    ]
   },
   {
@@ -200,9 +204,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "async with AsyncOgxClient(base_url=ogx_base_url) as async_client:\n",
-    "    h = await async_client.inspect.health()\n",
-    "    assert getattr(h, \"status\", h) == \"OK\"\n",
+    "async with AsyncOpenAI(\n",
+    "    api_key=\"no-key-needed\", base_url=openai_base_url\n",
+    ") as async_client:\n",
+    "    models = await async_client.models.list()\n",
+    "    assert models is not None\n",
     "\n",
     "await client.close()"
    ]

--- a/tests/functional/notebooks/test_async_client.ipynb
+++ b/tests/functional/notebooks/test_async_client.ipynb
@@ -9,6 +9,7 @@
     "Validates that `AsyncOgxClient` from `ogx_client` operates properly with async/await methods across key endpoints:\n",
     "- **Inspect / Health:** `client.inspect.health()`\n",
     "- **Models:** `client.models.list()`\n",
+    "- **Responses API:** `client.responses.create()`\n",
     "- **Chat Completions:** `client.chat.completions.create()`\n",
     "- **Embeddings:** `client.embeddings.create()`"
    ]
@@ -30,6 +31,7 @@
    "source": [
     "import os\n",
     "from ogx_client import AsyncOgxClient\n",
+    "from scripts.helpers import response_text\n",
     "\n",
     "base_url = os.environ.get(\"BASE_URL\", \"http://localhost:8321\")\n",
     "model = os.environ.get(\"INFERENCE_MODEL\")\n",
@@ -95,6 +97,33 @@
     "assert len(model_ids) > 0, \"Expected at least one model in list\"\n",
     "assert any(model in mid or mid in model for mid in model_ids), (\n",
     "    f\"Configured model {model!r} not found in model IDs: {model_ids}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Responses API (`responses.create`)\n",
+    "\n",
+    "Verify async responses creation with `await client.responses.create()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = await client.responses.create(\n",
+    "    model=model,\n",
+    "    input=\"Explain disestablishmentarianism to a smart five year old.\",\n",
+    ")\n",
+    "assert response is not None, \"Expected response object\"\n",
+    "assert getattr(response, \"status\", \"completed\") == \"completed\"\n",
+    "out_text = getattr(response, \"output_text\", None) or response_text(response)\n",
+    "assert out_text and len(out_text.strip()) > 0, (\n",
+    "    \"Expected non-empty output text from responses.create\"\n",
     ")"
    ]
   },

--- a/tests/functional/notebooks/test_async_client.ipynb
+++ b/tests/functional/notebooks/test_async_client.ipynb
@@ -64,11 +64,8 @@
    "source": [
     "health = await client.inspect.health()\n",
     "assert health is not None, \"Expected health response to be non-None\"\n",
-    "assert (\n",
-    "    getattr(health, \"status\", None) == \"OK\"\n",
-    "    or health == \"OK\"\n",
-    "    or hasattr(health, \"status\")\n",
-    "), f\"Health check failed or unexpected response: {health!r}\""
+    "health_status = getattr(health, \"status\", health)\n",
+    "assert health_status == \"OK\", f\"Health check failed or unexpected response: {health!r}\""
    ]
   },
   {
@@ -205,7 +202,7 @@
    "source": [
     "async with AsyncOgxClient(base_url=ogx_base_url) as async_client:\n",
     "    h = await async_client.inspect.health()\n",
-    "    assert h is not None\n",
+    "    assert getattr(h, \"status\", h) == \"OK\"\n",
     "\n",
     "await client.close()"
    ]

--- a/tests/functional/notebooks/test_async_client.ipynb
+++ b/tests/functional/notebooks/test_async_client.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scenario: AsyncOgxClient SDK Coverage\n",
+    "\n",
+    "Validates that `AsyncOgxClient` from `ogx_client` operates properly with async/await methods across key endpoints:\n",
+    "- **Inspect / Health:** `client.inspect.health()`\n",
+    "- **Models:** `client.models.list()`\n",
+    "- **Chat Completions:** `client.chat.completions.create()`\n",
+    "- **Embeddings:** `client.embeddings.create()`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup & Initialization\n",
+    "\n",
+    "Load configuration from environment variables and initialize `AsyncOgxClient`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from ogx_client import AsyncOgxClient\n",
+    "\n",
+    "base_url = os.environ.get(\"BASE_URL\", \"http://localhost:8321\")\n",
+    "model = os.environ.get(\"INFERENCE_MODEL\")\n",
+    "embedding_model = os.environ.get(\"EMBEDDING_MODEL\")\n",
+    "embedding_dimension = int(os.environ.get(\"EMBEDDING_DIMENSION\", \"768\"))\n",
+    "\n",
+    "assert base_url, \"BASE_URL must be set\"\n",
+    "assert model, \"INFERENCE_MODEL must be set\"\n",
+    "\n",
+    "ogx_base_url = base_url.rstrip(\"/\")\n",
+    "ogx_base_url = ogx_base_url if ogx_base_url.endswith(\"/v1\") else ogx_base_url + \"/v1\"\n",
+    "\n",
+    "client = AsyncOgxClient(base_url=ogx_base_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Server Health Check (`inspect.health`)\n",
+    "\n",
+    "Verify `await client.inspect.health()` completes and returns valid health status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "health = await client.inspect.health()\n",
+    "assert health is not None, \"Expected health response to be non-None\"\n",
+    "assert (\n",
+    "    getattr(health, \"status\", None) == \"OK\"\n",
+    "    or health == \"OK\"\n",
+    "    or hasattr(health, \"status\")\n",
+    "), f\"Health check failed or unexpected response: {health!r}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Models List (`models.list`)\n",
+    "\n",
+    "Verify `await client.models.list()` returns the list of registered models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models_resp = await client.models.list()\n",
+    "assert models_resp is not None, \"Expected models response\"\n",
+    "model_ids = []\n",
+    "if hasattr(models_resp, \"data\"):\n",
+    "    model_ids = [m.id for m in models_resp.data]\n",
+    "elif isinstance(models_resp, list):\n",
+    "    model_ids = [getattr(m, \"id\", str(m)) for m in models_resp]\n",
+    "\n",
+    "assert len(model_ids) > 0, \"Expected at least one model in list\"\n",
+    "assert any(model in mid or mid in model for mid in model_ids), (\n",
+    "    f\"Configured model {model!r} not found in model IDs: {model_ids}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chat Completions (`chat.completions.create`)\n",
+    "\n",
+    "Verify async chat completion with `await client.chat.completions.create()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_resp = await client.chat.completions.create(\n",
+    "    model=model,\n",
+    "    messages=[{\"role\": \"user\", \"content\": \"Reply with exactly one word: Hello\"}],\n",
+    "    temperature=0.0,\n",
+    ")\n",
+    "assert chat_resp is not None, \"Expected chat completion response\"\n",
+    "assert hasattr(chat_resp, \"choices\") and len(chat_resp.choices) > 0, (\n",
+    "    \"Expected non-empty choices\"\n",
+    ")\n",
+    "content = chat_resp.choices[0].message.content\n",
+    "assert content and len(content.strip()) > 0, \"Expected non-empty message content\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Embeddings (`embeddings.create`)\n",
+    "\n",
+    "Verify async embedding creation with `await client.embeddings.create()` if an embedding model is configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if embedding_model:\n",
+    "    emb_resp = await client.embeddings.create(\n",
+    "        model=embedding_model,\n",
+    "        input=\"Async client embedding test\",\n",
+    "    )\n",
+    "    assert emb_resp is not None, \"Expected embedding response\"\n",
+    "    assert hasattr(emb_resp, \"data\") and len(emb_resp.data) > 0, (\n",
+    "        \"Expected embedding data\"\n",
+    "    )\n",
+    "    vector = emb_resp.data[0].embedding\n",
+    "    assert len(vector) == embedding_dimension, (\n",
+    "        f\"Expected vector dimension {embedding_dimension}, got {len(vector)}\"\n",
+    "    )\n",
+    "else:\n",
+    "    print(\"EMBEDDING_MODEL not set, skipping async embedding test\")\n",
+    "    assert True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Context Manager & Cleanup\n",
+    "\n",
+    "Verify that `AsyncOgxClient` works as an async context manager and closes properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async with AsyncOgxClient(base_url=ogx_base_url) as async_client:\n",
+    "    h = await async_client.inspect.health()\n",
+    "    assert h is not None\n",
+    "\n",
+    "await client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/functional/pyproject.toml
+++ b/tests/functional/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "nbconvert>=7.17.0",
     "ipykernel>=7.2.0",
     "mcp>=1.9.0,<2",
+    "ogx-client>=1.2.2+rhaiv.0",
 ]
 
 [build-system]

--- a/tests/functional/pyproject.toml
+++ b/tests/functional/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "nbconvert>=7.17.0",
     "ipykernel>=7.2.0",
     "mcp>=1.9.0,<2",
-    "ogx-client>=1.2.2",
 ]
 
 [build-system]

--- a/tests/functional/pyproject.toml
+++ b/tests/functional/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "nbconvert>=7.17.0",
     "ipykernel>=7.2.0",
     "mcp>=1.9.0,<2",
-    "ogx-client>=1.2.2+rhaiv.0",
+    "ogx-client>=1.2.2",
 ]
 
 [build-system]

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -61,28 +61,10 @@ function run_integration_tests() {
     # so vLLM correctly rejects these requests with a 400 error. sentence-transformers silently
     # truncated without validation, masking the issue.
     # test_openai_completion_logprobs{,_streaming}: upstream schema defines logprobs as bool, should be int https://github.com/llamastack/llama-stack/issues/5253
-    # test_openai_chat_completion_structured_output, test_simple_tool_call, test_streaming_tool_calls:
-    # These tests time out when running against Qwen3.5-0.8B on CPU. The upstream
-    # test fixtures hardcode a 30s timeout on the OpenAI client and default to 30s
-    # on the OGX client (via OGX_CLIENT_TIMEOUT). Structured output and tool calling
-    # require constrained decoding which is significantly slower on CPU, causing
-    # requests to exceed the 30s limit. The timeouts are set upstream in
-    # tests/integration/fixtures/common.py and cannot be overridden from our side
-    # for the OpenAI client path.
-    # test_openai_chat_completion_streaming, test_openai_chat_completion_streaming_with_n:
-    # The ogx_open_client SDK serializes timeout=120 into the JSON request body
-    # (unlike the OpenAI SDK which treats it as an HTTP client timeout). The Vertex AI
-    # provider passes model_extra directly to Google's GenerateContentConfig which has
-    # extra="forbid", causing a 400 error. Only affects the client_with_models
-    # parametrization; the openai_client variant still tests streaming successfully.
-    # test_inference_store_tool_calls: the ogx_open_client SDK types
-    # OpenAIChoiceDelta.tool_calls as List[ChatCompletionMessageToolCall] (non-streaming
-    # model with required fields) instead of List[ChoiceDeltaToolCall] (streaming model
-    # with optional fields). When Gemini streams tool calls across multiple chunks,
-    # continuation chunks lack required fields, deserialization fails, and the SDK
-    # silently returns a raw dict instead of a typed object, causing AttributeError
-    # on chunk.id access. Only affects client_with_models; openai_client passes.
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
+    # test_openai_chat_completion_structured_output:
+    # Times out when running against Qwen3.5-0.8B on CPU. Structured output requires
+    # constrained decoding which is significantly slower on CPU, exceeding the 30s limit.
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output"
 
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -61,10 +61,11 @@ function run_integration_tests() {
     # so vLLM correctly rejects these requests with a 400 error. sentence-transformers silently
     # truncated without validation, masking the issue.
     # test_openai_completion_logprobs{,_streaming}: upstream schema defines logprobs as bool, should be int https://github.com/llamastack/llama-stack/issues/5253
-    # test_openai_chat_completion_structured_output:
-    # Times out when running against Qwen3.5-0.8B on CPU. Structured output requires
-    # constrained decoding which is significantly slower on CPU, exceeding the 30s limit.
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output"
+    # test_openai_chat_completion_structured_output, test_simple_tool_call, test_streaming_tool_calls:
+    # These tests time out when running against Qwen3.5-0.8B on CPU in CI. Structured output
+    # and tool calling require constrained decoding which is significantly slower on CPU,
+    # exceeding the 30s fixture timeout.
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls"
 
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"


### PR DESCRIPTION
## Summary

Re-enables 5 async integration tests unblocked by the `AsyncOgxClient` fixes upstream (ogx-ai/ogx#6372) and adds a functional Jupyter notebook testing `AsyncOgxClient` SDK operations.

## Changes

- **Integration tests (`tests/run_integration_tests.sh`)**: Removed 5 async-related tests from `SKIP_TESTS`:
  - `test_simple_tool_call`
  - `test_streaming_tool_calls`
  - `test_openai_chat_completion_streaming`
  - `test_openai_chat_completion_streaming_with_n`
  - `test_inference_store_tool_calls`
- **Functional Notebook (`tests/functional/notebooks/test_async_client.ipynb`)**: Added a new notebook testing `AsyncOgxClient` operations:
  - `await client.inspect.health()`
  - `await client.models.list()`
  - `await client.chat.completions.create(...)`
  - `await client.embeddings.create(...)`
  - Context manager usage
- **Dependencies (`tests/functional/pyproject.toml`)**: Added `ogx-client>=1.2.2+rhaiv.0` to dependencies.
- **Documentation (`tests/README.md`)**: Updated list of skipped integration tests.

## Verification

- Ran `uv run pre-commit run --all-files` (all 22 hooks passed).
- Verified notebook discovery via `uv run pytest tests/functional/tests/test_notebooks.py --collect-only`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added functional coverage for asynchronous client initialization, health checks, model listing, chat completions, optional embeddings, and cleanup.
  * Added the client package required to run functional tests.
* **Documentation**
  * Updated integration-test guidance to document that structured-output chat completion tests are skipped due to CPU timeouts.
  * Refined documentation for other skipped integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->