### PR TITLE
fix: skip integration tests incompatible with Gemini/Vertex AI provider

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,11 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_simple_tool_call`
 - `test_streaming_tool_calls`
 
+**Gemini / Vertex AI provider incompatible tests (`client_with_models`):**
+- `test_openai_chat_completion_streaming`
+- `test_openai_chat_completion_streaming_with_n`
+- `test_inference_store_tool_calls`
+
 **Requires vLLM >= v0.12.0** ([ogx/ogx#4984](https://github.com/ogx/ogx/issues/4984)):
 - `test_openai_completion_guided_choice`
 

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -65,7 +65,19 @@ function run_integration_tests() {
     # These tests time out when running against Qwen3.5-0.8B on CPU in CI. Structured output
     # and tool calling require constrained decoding which is significantly slower on CPU,
     # exceeding the 30s fixture timeout.
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls"
+    # test_openai_chat_completion_streaming, test_openai_chat_completion_streaming_with_n:
+    # The ogx_open_client SDK serializes timeout=120 into the JSON request body
+    # (unlike the OpenAI SDK which treats it as an HTTP client timeout). The Vertex AI
+    # provider passes model_extra directly to Google's GenerateContentConfig which has
+    # extra="forbid", causing a 400 error.
+    # test_inference_store_tool_calls: the ogx_open_client SDK types
+    # OpenAIChoiceDelta.tool_calls as List[ChatCompletionMessageToolCall] (non-streaming
+    # model with required fields) instead of List[ChoiceDeltaToolCall] (streaming model
+    # with optional fields). When Gemini streams tool calls across multiple chunks,
+    # continuation chunks lack required fields, deserialization fails, and the SDK
+    # silently returns a raw dict instead of a typed object, causing AttributeError
+    # on chunk.id access.
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
 
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"


### PR DESCRIPTION
## Summary

Restores skips in `SKIP_TESTS` for tests that fail when executed against the Gemini / Vertex AI provider (`ENABLE_GEMINI=1` in CI):

- `test_openai_chat_completion_streaming`
- `test_openai_chat_completion_streaming_with_n`
- `test_inference_store_tool_calls`

## Failure Root Causes

1. **`test_openai_chat_completion_streaming` & `streaming_with_n`**:
   The `ogx_open_client` SDK serializes `timeout=120` into the JSON request body (unlike the OpenAI SDK which treats it as an HTTP client timeout). The Vertex AI provider passes `model_extra` directly to Google's `GenerateContentConfig` which has `extra="forbid"`, triggering a 400 error (`Invalid JSON payload received. Unknown name "timeout": Cannot find field`).
2. **`test_inference_store_tool_calls`**:
   `ogx_open_client` SDK types `OpenAIChoiceDelta.tool_calls` with required non-streaming fields. When Gemini streams tool calls across multiple chunks, continuation chunks lack these required fields, causing deserialization failure and `AttributeError: 'dict' object has no attribute 'id'`.

## Verification

- Verified `uv run pre-commit run --all-files` (all 22 hooks passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented integration tests that are incompatible with Gemini and Vertex AI.

* **Tests**
  * Updated integration-test handling to skip streaming and inference-store tool-call scenarios affected by provider limitations and SDK behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->