### PR TITLE
fix: apply model-conditional integration test skips for Gemini, Anthropic, and CPU backends

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,11 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_simple_tool_call`
 - `test_streaming_tool_calls`
 
+**Gemini / Vertex AI provider incompatible tests (`client_with_models`):**
+- `test_openai_chat_completion_streaming`
+- `test_openai_chat_completion_streaming_with_n`
+- `test_inference_store_tool_calls`
+
 **Requires vLLM >= v0.12.0** ([ogx/ogx#4984](https://github.com/ogx/ogx/issues/4984)):
 - `test_openai_completion_guided_choice`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,12 +81,12 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_tool_with_complex_schema`
 - `test_tool_without_schema`
 
-**Structured output and tool-calling tests timing out on CPU:**
+**Structured output and tool-calling tests timing out on CPU (skipped for `vllm` / CPU models):**
 - `test_openai_chat_completion_structured_output`
 - `test_simple_tool_call`
 - `test_streaming_tool_calls`
 
-**Gemini / Vertex AI provider incompatible tests (`client_with_models`):**
+**Gemini / Vertex AI provider incompatible tests (skipped for `gemini` / `vertexai` models):**
 - `test_openai_chat_completion_streaming`
 - `test_openai_chat_completion_streaming_with_n`
 - `test_inference_store_tool_calls`

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,6 +91,9 @@ Some upstream tests are currently skipped, grouped by reason:
 - `test_openai_chat_completion_streaming_with_n`
 - `test_inference_store_tool_calls`
 
+**Anthropic provider missing strict field in structured output schema (skipped for `anthropic` models):**
+- `test_openai_chat_completion_structured_output`
+
 **Requires vLLM >= v0.12.0** ([ogx/ogx#4984](https://github.com/ogx/ogx/issues/4984)):
 - `test_openai_completion_guided_choice`
 

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -65,7 +65,19 @@ function run_integration_tests() {
     # These tests time out when running against Qwen3.5-0.8B on CPU in CI. Structured output
     # and tool calling require constrained decoding which is significantly slower on CPU,
     # exceeding the 30s fixture timeout.
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls"
+    # test_openai_chat_completion_streaming, test_openai_chat_completion_streaming_with_n:
+    # The ogx_open_client SDK serializes timeout=120 into the JSON request body
+    # (unlike the OpenAI SDK which treats it as an HTTP client timeout). The Vertex AI
+    # provider passes model_extra directly to Google's GenerateContentConfig which has
+    # extra="forbid", causing a 400 error.
+    # test_inference_store_tool_calls: the ogx_open_client SDK types
+    # OpenAIChoiceDelta.tool_calls as List[ChatCompletionMessageToolCall] (non-streaming
+    # model with required fields) instead of List[ChoiceDeltaToolCall] (streaming model
+    # with optional fields). When Gemini streams tool calls across multiple chunks,
+    # continuation chunks lack required fields, deserialization fails, and the SDK
+    # silently returns a raw dict instead of a typed object, causing AttributeError
+    # on chunk.id access.
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
 
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -75,6 +75,12 @@ function run_integration_tests() {
         SKIP_TESTS="$SKIP_TESTS or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
     fi
 
+    # Anthropic provider specific structured output schema error
+    # - test_openai_chat_completion_structured_output: Anthropic requires response_format.json_schema.strict which upstream test fixtures omit.
+    if [[ "$model" == anthropic* ]]; then
+        SKIP_TESTS="$SKIP_TESTS or test_openai_chat_completion_structured_output"
+    fi
+
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"
     if [ ! -f "$STACK_CONFIG_PATH" ]; then

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -52,7 +52,7 @@ function run_integration_tests() {
 
     cd "$WORK_DIR"
 
-    # Test to skip
+    # Base tests to skip across all models
     # TODO: re-enable the 2 chat_completion_non_streaming tests once they contain include max tokens (to prevent them from rambling)
     # test_openai_completion_guided_choice needs vllm  >= v0.12.0 https://github.com/llamastack/llama-stack/issues/4984
     # test_openai_embeddings_with_dimensions and test_openai_embeddings_with_encoding_format_base64
@@ -61,23 +61,19 @@ function run_integration_tests() {
     # so vLLM correctly rejects these requests with a 400 error. sentence-transformers silently
     # truncated without validation, masking the issue.
     # test_openai_completion_logprobs{,_streaming}: upstream schema defines logprobs as bool, should be int https://github.com/llamastack/llama-stack/issues/5253
-    # test_openai_chat_completion_structured_output, test_simple_tool_call, test_streaming_tool_calls:
-    # These tests time out when running against Qwen3.5-0.8B on CPU in CI. Structured output
-    # and tool calling require constrained decoding which is significantly slower on CPU,
-    # exceeding the 30s fixture timeout.
-    # test_openai_chat_completion_streaming, test_openai_chat_completion_streaming_with_n:
-    # The ogx_open_client SDK serializes timeout=120 into the JSON request body
-    # (unlike the OpenAI SDK which treats it as an HTTP client timeout). The Vertex AI
-    # provider passes model_extra directly to Google's GenerateContentConfig which has
-    # extra="forbid", causing a 400 error.
-    # test_inference_store_tool_calls: the ogx_open_client SDK types
-    # OpenAIChoiceDelta.tool_calls as List[ChatCompletionMessageToolCall] (non-streaming
-    # model with required fields) instead of List[ChoiceDeltaToolCall] (streaming model
-    # with optional fields). When Gemini streams tool calls across multiple chunks,
-    # continuation chunks lack required fields, deserialization fails, and the SDK
-    # silently returns a raw dict instead of a typed object, causing AttributeError
-    # on chunk.id access.
-    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
+    SKIP_TESTS="test_text_chat_completion_tool_calling_tools_not_in_request or test_text_chat_completion_structured_output or test_text_chat_completion_non_streaming or test_openai_chat_completion_non_streaming or test_openai_chat_completion_with_tool_choice_none or test_openai_chat_completion_with_tools or test_openai_format_preserves_complex_schemas or test_multiple_tools_with_different_schemas or test_tool_with_complex_schema or test_tool_without_schema or test_openai_completion_guided_choice or test_openai_embeddings_with_dimensions or test_openai_embeddings_with_encoding_format_base64 or test_openai_completion_logprobs or test_openai_completion_logprobs_streaming"
+
+    # CPU-constrained tool calling / structured output timeouts (e.g. local vLLM on CPU in CI)
+    if [[ "$model" == vllm* ]] || [[ "$model" == *Qwen* ]]; then
+        SKIP_TESTS="$SKIP_TESTS or test_openai_chat_completion_structured_output or test_simple_tool_call or test_streaming_tool_calls"
+    fi
+
+    # Gemini / Vertex AI provider specific payload & deserialization bugs
+    # - test_openai_chat_completion_streaming{,_with_n}: ogx_open_client SDK serializes timeout=120 into HTTP body, rejected with 400 by Vertex AI.
+    # - test_inference_store_tool_calls: ogx_open_client SDK tool call chunk deserialization fails on Gemini streaming.
+    if [[ "$model" == gemini* ]] || [[ "$model" == vertexai* ]]; then
+        SKIP_TESTS="$SKIP_TESTS or test_openai_chat_completion_streaming or test_openai_chat_completion_streaming_with_n or test_inference_store_tool_calls"
+    fi
 
     # Dynamically determine the path to config.yaml from the original script directory
     STACK_CONFIG_PATH="$SCRIPT_DIR/../distribution/config.yaml"


### PR DESCRIPTION
## Summary

Restores and refines model-conditional skips in `tests/run_integration_tests.sh` so tests run wherever supported and are skipped only on specific backends with known provider/model limitations.

## Test Coverage & Skip Matrix

| Model / Backend | Extra Skipped Tests | Tests That RUN & PASS |
|---|---|---|
| **OpenAI (`openai/gpt-5-nano`)** | **None** | • `test_openai_chat_completion_streaming`<br>• `test_openai_chat_completion_streaming_with_n`<br>• `test_inference_store_tool_calls`<br>• `test_openai_chat_completion_structured_output`<br>• `test_simple_tool_call`<br>• `test_streaming_tool_calls` |
| **vLLM / CPU (`vllm*`, `*Qwen*`)** | • `test_simple_tool_call`<br>• `test_streaming_tool_calls`<br>• `test_openai_chat_completion_structured_output` | • `test_openai_chat_completion_streaming`<br>• `test_openai_chat_completion_streaming_with_n`<br>• `test_inference_store_tool_calls` |
| **Gemini / Vertex AI (`gemini*`, `vertexai*`)** | • `test_openai_chat_completion_streaming`<br>• `test_openai_chat_completion_streaming_with_n`<br>• `test_inference_store_tool_calls` | • `test_simple_tool_call`<br>• `test_streaming_tool_calls`<br>• `test_openai_chat_completion_structured_output` |
| **Anthropic (`anthropic*`)** | • `test_openai_chat_completion_structured_output` | • `test_openai_chat_completion_streaming`<br>• `test_openai_chat_completion_streaming_with_n`<br>• `test_inference_store_tool_calls`<br>• `test_simple_tool_call`<br>• `test_streaming_tool_calls` |

## Failure Root Causes

- **Gemini / Vertex AI**:
  - `ogx_open_client` SDK serializes `timeout=120` into the HTTP request body (rejected with `400 Bad Request` by Google API).
  - `ogx_open_client` SDK tool call chunk deserialization fails on Gemini streaming (`AttributeError: 'dict' object has no attribute 'id'`).
- **Anthropic**:
  - Requires `response_format.json_schema.strict` boolean field which upstream test fixtures omit (`BadRequestError: 400 - response_format.json_schema.strict: Field required`).
- **vLLM on CPU**:
  - Constrained decoding for structured output and tool calling exceeds the hardcoded 30s fixture timeout in CI.

## Verification

- Pre-commit hooks verified (`uv run pre-commit run --all-files`, 22/22 passed).