### PR TITLE
ci: regenerate distribution docs in regenerate-artifacts action

### DIFF
--- a/.github/actions/regenerate-artifacts/action.yml
+++ b/.github/actions/regenerate-artifacts/action.yml
@@ -1,5 +1,5 @@
 name: Regenerate distribution artifacts
-description: Run the build scripts that regenerate config, lockfiles, Containerfile, and verify secrets
+description: Run the build scripts that regenerate config, lockfiles, Containerfile, distribution docs, and verify secrets
 
 inputs:
   ogx-version:
@@ -26,3 +26,4 @@ runs:
         uv run build/gen_config.py
         ./build/run_gen_lockfile.sh
         uv run build/gen_containerfile.py
+        uv run build/gen_distro_docs.py


### PR DESCRIPTION
### Description

The Create or Update Release Branch workflow fails at Run pre-commit on every version bump: the doc-gen hook regenerates distribution/README.md, but the regenerate-artifacts composite action does not run that generator, so the hook always finds a stale README, modifies it, and pre-commit exits 1 before Commit and push. Observed on [run 32265582598](https://github.com/opendatahub-io/ogx-distribution/actions/runs/32265582598) (release-3.6-ea.1 from tag v1.3.0+rhaiv.0), where doc-gen was the only failing hook and distribution/README.md the only file it modified.

This adds build/gen_distro_docs.py to the composite action so its outputs cover every file-mutating pre-commit hook.

### How Has This Been Tested?

Locally reproduced the exact workflow sequence on a clone: set OGX_VERSION=v1.3.0+rhaiv.0 in build/build.env, ran the composite's generators (gen_config.py, run_gen_lockfile.sh in the container, gen_containerfile.py), then pre-commit. Without this change, doc-gen fails with "files were modified by this hook" on distribution/README.md, matching the CI log. With this change (gen_distro_docs.py added), the full pre-commit suite passes with exit 0.

### Test Impact

None; CI-only change.